### PR TITLE
fix(context): forward all BucketingAttributes to ExperienceManager

### DIFF
--- a/packages/Php-sdk/src/Context.php
+++ b/packages/Php-sdk/src/Context.php
@@ -104,15 +104,13 @@ final class Context implements ContextInterface
         }
 
         $visitorProperties = $this->getVisitorProperties($attributes?->getVisitorProperties());
+        $forwardedData = $attributes ? get_object_vars($attributes) : [];
+        $forwardedData['visitorProperties'] = $visitorProperties;
+        $forwardedData['environment'] = $forwardedData['environment'] ?? $this->environment;
         $result = $this->experienceManager->selectVariation(
             $this->visitorId,
             $experienceKey,
-            new BucketingAttributes([
-                'visitorProperties' => $visitorProperties,
-                'locationProperties' => $attributes?->getLocationProperties(),
-                'updateVisitorProperties' => $attributes?->getUpdateVisitorProperties(),
-                'environment' => $attributes?->getEnvironment() ?? $this->environment,
-            ])
+            new BucketingAttributes($forwardedData)
         );
 
         if ($result === null
@@ -153,15 +151,13 @@ final class Context implements ContextInterface
         }
 
         $visitorProperties = $this->getVisitorProperties($attributes?->getVisitorProperties());
+        $forwardedData = $attributes ? get_object_vars($attributes) : [];
+        $forwardedData['visitorProperties'] = $visitorProperties;
+        $forwardedData['environment'] = $forwardedData['environment'] ?? $this->environment;
 
         $bucketedVariations = $this->experienceManager->selectVariations(
             $this->visitorId,
-            new BucketingAttributes([
-                'visitorProperties' => $visitorProperties,
-                'locationProperties' => $attributes?->getLocationProperties(),
-                'updateVisitorProperties' => $attributes?->getUpdateVisitorProperties(),
-                'environment' => $attributes?->getEnvironment() ?? $this->environment,
-            ])
+            new BucketingAttributes($forwardedData)
         );
 
         $dtos = [];

--- a/packages/Php-sdk/tests/ContextTest.php
+++ b/packages/Php-sdk/tests/ContextTest.php
@@ -133,6 +133,88 @@ class ContextTest extends TestCase
         }
     }
 
+    public function testRunExperienceForwardsAllBucketingAttributes(): void
+    {
+        $realManager = $this->experienceManager;
+        $captured = null;
+
+        $spy = $this->createMock(\ConvertSdk\Interfaces\ExperienceManagerInterface::class);
+        $spy->method('selectVariation')->willReturnCallback(
+            function (string $visitorId, string $experienceKey, BucketingAttributes $attributes) use ($realManager, &$captured) {
+                $captured = $attributes;
+                return $realManager->selectVariation($visitorId, $experienceKey, $attributes);
+            }
+        );
+
+        $context = new Context(
+            $this->config,
+            $this->visitorId,
+            $this->eventManager,
+            $spy,
+            $this->featureManager,
+            $this->dataManager,
+            $this->segmentsManager,
+            $this->apiManager,
+        );
+
+        $context->runExperience('test-experience-ab-fullstack-2', new BucketingAttributes([
+            'locationProperties' => ['url' => 'https://convert.com/'],
+            'visitorProperties' => ['varName3' => 'something'],
+            'enableTracking' => false,
+            'forceVariationId' => '100299461',
+            'ignoreLocationProperties' => true,
+            'updateVisitorProperties' => true,
+        ]));
+
+        $this->assertNotNull($captured);
+        $this->assertFalse($captured->enableTracking);
+        $this->assertSame('100299461', $captured->forceVariationId);
+        $this->assertTrue($captured->ignoreLocationProperties);
+        $this->assertTrue($captured->updateVisitorProperties);
+        $this->assertSame(['url' => 'https://convert.com/'], $captured->locationProperties);
+    }
+
+    public function testRunExperiencesForwardsAllBucketingAttributes(): void
+    {
+        $realManager = $this->experienceManager;
+        $captured = null;
+
+        $spy = $this->createMock(\ConvertSdk\Interfaces\ExperienceManagerInterface::class);
+        $spy->method('selectVariations')->willReturnCallback(
+            function (string $visitorId, BucketingAttributes $attributes) use ($realManager, &$captured) {
+                $captured = $attributes;
+                return $realManager->selectVariations($visitorId, $attributes);
+            }
+        );
+
+        $context = new Context(
+            $this->config,
+            $this->visitorId,
+            $this->eventManager,
+            $spy,
+            $this->featureManager,
+            $this->dataManager,
+            $this->segmentsManager,
+            $this->apiManager,
+        );
+
+        $context->runExperiences(new BucketingAttributes([
+            'locationProperties' => ['url' => 'https://convert.com/'],
+            'visitorProperties' => ['varName3' => 'something'],
+            'enableTracking' => false,
+            'forceVariationId' => '100299461',
+            'ignoreLocationProperties' => true,
+            'updateVisitorProperties' => true,
+        ]));
+
+        $this->assertNotNull($captured);
+        $this->assertFalse($captured->enableTracking);
+        $this->assertSame('100299461', $captured->forceVariationId);
+        $this->assertTrue($captured->ignoreLocationProperties);
+        $this->assertTrue($captured->updateVisitorProperties);
+        $this->assertSame(['url' => 'https://convert.com/'], $captured->locationProperties);
+    }
+
     public function testGetSingleFeatureWithStatus(): void
     {
         $featureKey = 'feature-2';


### PR DESCRIPTION
## Summary

`Context::runExperience` and `Context::runExperiences` rebuilt a fresh `BucketingAttributes` object with only four hardcoded keys (`visitorProperties`, `locationProperties`, `updateVisitorProperties`, `environment`) before forwarding to `ExperienceManager::selectVariation` / `selectVariations`. Every other `BucketingAttributes` field — `enableTracking`, `forceVariationId`, `ignoreLocationProperties`, `typeCasting`, `experienceKeys` — was silently dropped.

The most user-visible consequence: a caller invoking `$context->runExperience($key, new BucketingAttributes(['enableTracking' => false]))` still fires the bucketing track event, because by the time the call reaches `DataManager::_getBucketingByField` (which reads `$attributes->enableTracking ?? true`), the field has been discarded one layer up. Same for `forceVariationId` (the forced variation was never honored) and `ignoreLocationProperties`.

## Root cause

A whitelist-then-rebuild pattern in `Context` instead of spread-then-override. Two transforms must happen at the Context layer:
1. `visitorProperties` must be merged with stored visitor props via `getVisitorProperties()`.
2. `environment` must default to `$this->environment` when the caller omits it.

Everything else can pass through unmodified; `BucketingAttributes::__construct` already does `?? null` defaulting per key, so extra/unknown fields are safe.

## Fix

```php
// before
new BucketingAttributes([
    'visitorProperties' => $visitorProperties,
    'locationProperties' => $attributes?->getLocationProperties(),
    'updateVisitorProperties' => $attributes?->getUpdateVisitorProperties(),
    'environment' => $attributes?->getEnvironment() ?? $this->environment,
])

// after
$forwardedData = $attributes ? get_object_vars($attributes) : [];
$forwardedData['visitorProperties'] = $visitorProperties;
$forwardedData['environment'] = $forwardedData['environment'] ?? $this->environment;
new BucketingAttributes($forwardedData)
```

Applied identically to `runExperience` and `runExperiences`.

`get_object_vars()` is the PHP analog to JS's object-spread; it copies all public properties of `$attributes` into an array, then we override the two we need to transform.

## Tests

Added two cases in `packages/Php-sdk/tests/ContextTest.php`:
- `testRunExperienceForwardsAllBucketingAttributes`
- `testRunExperiencesForwardsAllBucketingAttributes`

Both wire a PHPUnit mock of `ExperienceManagerInterface` that captures the `BucketingAttributes` passed in and delegates to the real manager. They assert that `enableTracking`, `forceVariationId`, `ignoreLocationProperties`, and `updateVisitorProperties` survive the trip through `Context`. Use `enableTracking: false` to keep the path side-effect-free.

## Test plan

- [x] `phpunit packages/Php-sdk/tests/ContextTest.php` → 39 tests pass, 208 assertions
- [x] `phpunit packages/Php-sdk/tests/` → 176 tests pass, 539 assertions (no regressions)
- [x] Existing `testRunExperience` and `testGetVariationsAcrossAllExperiences` still pass — happy path unchanged

## Notes

- Mirrors the JS-SDK fix in convertcom/javascript-sdk#382 — same bug, same shape, ported to PHP idiom.
- Fix is API-surface-neutral. Callers that were never passing the dropped fields see no change. Callers that were passing them and silently getting the default behavior will now get the documented behavior they expected from the public `BucketingAttributes` type all along.
- No changes to `BucketingAttributes` type, `DataManager`, `ExperienceManager`, or any downstream layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)