### PR TITLE
feat(api): always announce as Convert SDK via ConvertAgent User-Agent

### DIFF
--- a/packages/Api/src/ApiManager.php
+++ b/packages/Api/src/ApiManager.php
@@ -216,6 +216,12 @@ class ApiManager implements ApiManagerInterface
             $request = $request->withBody($body);
         }
 
+        // Always announce as Convert SDK traffic so the metrics-endpoint
+        // bot filter recognises us via its `isConvertAgentUA` bypass. Set
+        // after the header merge so neither $headers nor $defaultHeaders
+        // can override — the announcement is an SDK invariant.
+        $request = $request->withHeader('User-Agent', 'ConvertAgent/1.0');
+
         $response = $this->httpClient->sendRequest($request);
 
         $rawBody = $response->getBody()->getContents();

--- a/packages/Api/src/ApiManager.php
+++ b/packages/Api/src/ApiManager.php
@@ -56,6 +56,13 @@ class ApiManager implements ApiManagerInterface
      */
     private const DEFAULT_TRACK_ENDPOINT = '';
 
+    /**
+     * User-Agent advertised by the SDK so the metrics-endpoint bot
+     * filter recognises Convert traffic via its `isConvertAgentUA`
+     * bypass.
+     */
+    private const CONVERT_AGENT_USER_AGENT = 'ConvertAgent/1.0';
+
     /** @var VisitorsQueue Queue for tracking visitor requests */
     private VisitorsQueue $requestsQueue;
 
@@ -220,7 +227,7 @@ class ApiManager implements ApiManagerInterface
         // bot filter recognises us via its `isConvertAgentUA` bypass. Set
         // after the header merge so neither $headers nor $defaultHeaders
         // can override — the announcement is an SDK invariant.
-        $request = $request->withHeader('User-Agent', 'ConvertAgent/1.0');
+        $request = $request->withHeader('User-Agent', self::CONVERT_AGENT_USER_AGENT);
 
         $response = $this->httpClient->sendRequest($request);
 


### PR DESCRIPTION
## Summary

- Force `User-Agent: ConvertAgent/1.0` on every outbound HTTP request from `ApiManager`, applied **after** the per-call and default header merge so it cannot be overridden by config.
- Matches the metrics-endpoint's `isConvertAgentUA` bypass — replaces dependence on the source-field bypass for SDK-traffic identification.

## Why now

The May 19 metrics-endpoint isbot regression exposed that:

- `ConvertSDK::create()` lets customers override `network.source` via config (`packages/Php-sdk/src/Config/DefaultConfig.php:49` default `'php-sdk'`).
- A `VERSION` env-var override hook exists in `ConvertSDK.php:70-73` (for CI/release builds). If a future release stamps `VERSION=php2.1.0`, the wire `source` becomes `php2.1.0` and matches **neither** of the metrics-endpoint bypass conditions today (`endsWith('-sdk')` or `/^js\d+\.\d+\.\d+/`). Silent customer outage.

Baking the UA at the transport layer makes the announcement an SDK invariant — not config-driven, not env-driven, not customer-overridable. Metrics-endpoint code stays untouched (the `isConvertAgentUA` bypass has been in place since 2026-05-20).

## What stays in place

The source-field bypass at the metrics endpoint remains as legacy fallback for already-deployed SDK versions. Customers on older SDKs continue to work via the `endsWith('-sdk')` path.

## Test plan

- [ ] CI green on the existing PHPUnit / PHPStan / php-cs-fixer pipelines
- [ ] Manually verify with a PSR-18 client capable of echoing request headers (e.g., a `MockHttpClient` test) that `User-Agent: ConvertAgent/1.0` is present on outbound requests
- [ ] Smoke against staging metrics endpoint to confirm `botCheckSkipped` events fire with empty `source` + `userAgent: "ConvertAgent/1.0"` (the ConvertAgent UA bypass path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215080183580741