### PR TITLE
feat(parity): add exists/not_exists comparison operators + align visitor_type segment key

### DIFF
--- a/packages/Data/src/DataManager.php
+++ b/packages/Data/src/DataManager.php
@@ -1291,7 +1291,7 @@ final class DataManager implements DataManagerInterface
             'devices',
             'source',
             'campaign',
-            'visitor_type',
+            'visitorType',
             'country',
             'customSegments',
         ];

--- a/packages/Data/tests/DataManagerTest.php
+++ b/packages/Data/tests/DataManagerTest.php
@@ -83,7 +83,7 @@ class DataManagerTest extends TestCase
         'devices' => 'ALLPH',
         'source' => 'test',
         'campaign' => 'test',
-        'visitor_type' => 'new',
+        'visitorType' => 'new',
         'country' => 'US',
         'customSegments' => ['seg1', 'seg2'],
     ];

--- a/packages/Enums/src/SegmentsKeys.php
+++ b/packages/Enums/src/SegmentsKeys.php
@@ -11,6 +11,6 @@ enum SegmentsKeys: string
     case Devices = 'devices';
     case Source = 'source';
     case Campaign = 'campaign';
-    case VisitorType = 'visitor_type';
+    case VisitorType = 'visitorType';
     case CustomSegments = 'customSegments';
 }

--- a/packages/Php-sdk/tests/ContextTest.php
+++ b/packages/Php-sdk/tests/ContextTest.php
@@ -389,7 +389,7 @@ class ContextTest extends TestCase
     public function testCreateContextWithAttributes(): void
     {
         // Note: filterReportSegments() splits attributes:
-        // - Segment keys (browser, devices, source, campaign, visitor_type, country, customSegments) → stored via putSegments()
+        // - Segment keys (browser, devices, source, campaign, visitorType, country, customSegments) → stored via putSegments()
         // - Other keys → stored as visitorProperties (accessible via getAttributes())
         $attributes = ['plan' => 'premium', 'country' => 'DE'];
         $context = new Context(

--- a/packages/Utils/src/Comparisons.php
+++ b/packages/Utils/src/Comparisons.php
@@ -233,6 +233,53 @@ class Comparisons
     }
 
     /**
+     * Check that a value exists (is not null and not an empty string).
+     *
+     * Mirrors JS Comparisons.exists: true when value is NOT undefined/null/empty-string.
+     * testAgainst is accepted for dispatch-signature parity but unused.
+     *
+     * @param mixed $value The actual value to test
+     * @param mixed $testAgainst Unused; present for comparison-processor signature parity
+     * @param bool $negation Whether to invert the result
+     * @return bool True if the value exists (or does not, when negated)
+     */
+    public static function exists(mixed $value, mixed $testAgainst = null, bool $negation = false): bool
+    {
+        $valueExists = $value !== null && $value !== '';
+        return self::returnNegationCheck($valueExists, $negation);
+    }
+
+    /**
+     * Check that a value does NOT exist (is null or an empty string).
+     *
+     * Mirrors JS Comparisons.not_exists. Method name keeps the underscore so the
+     * wire match_type 'not_exists' resolves via RuleManager's get_class_methods() dispatch.
+     *
+     * @param mixed $value The actual value to test
+     * @param mixed $testAgainst Unused; present for comparison-processor signature parity
+     * @param bool $negation Whether to invert the result
+     * @return bool True if the value does not exist (or does, when negated)
+     */
+    public static function not_exists(mixed $value, mixed $testAgainst = null, bool $negation = false): bool
+    {
+        $valueNotExists = $value === null || $value === '';
+        return self::returnNegationCheck($valueNotExists, $negation);
+    }
+
+    /**
+     * Alias of not_exists (mirrors JS Comparisons.doesNotExist = not_exists).
+     *
+     * @param mixed $value The actual value to test
+     * @param mixed $testAgainst Unused; present for comparison-processor signature parity
+     * @param bool $negation Whether to invert the result
+     * @return bool True if the value does not exist (or does, when negated)
+     */
+    public static function doesNotExist(mixed $value, mixed $testAgainst = null, bool $negation = false): bool
+    {
+        return self::not_exists($value, $testAgainst, $negation);
+    }
+
+    /**
      * Apply negation check to a boolean result.
      *
      * @param bool $value The comparison result

--- a/tests/CrossSdk/RuleParityTest.php
+++ b/tests/CrossSdk/RuleParityTest.php
@@ -124,7 +124,7 @@ class RuleParityTest extends TestCase
     public function testAllComparisonCategoriesPresent(): void
     {
         $categories = array_column(self::$vectors['comparison_operators'], 'category');
-        $required = ['equals', 'equalsNumber', 'matches', 'less', 'lessEqual', 'contains', 'isIn', 'startsWith', 'endsWith', 'regexMatches'];
+        $required = ['equals', 'equalsNumber', 'matches', 'less', 'lessEqual', 'contains', 'isIn', 'startsWith', 'endsWith', 'regexMatches', 'exists', 'not_exists'];
 
         foreach ($required as $category) {
             $this->assertContains($category, $categories, "Missing comparison category: $category");
@@ -154,6 +154,15 @@ class RuleParityTest extends TestCase
     public function testRuleEvaluationVectorMinimumCount(): void
     {
         $this->assertGreaterThanOrEqual(10, count(self::$vectors['rule_evaluation']));
+    }
+
+    public function testVisitorTypeSegmentKeySerializesAsVisitorType(): void
+    {
+        $this->assertSame('visitorType', \ConvertSdk\Enums\SegmentsKeys::VisitorType->value);
+
+        // Round-trip: a visitorType segment survives VisitorSegments construction.
+        $segments = new \OpenAPI\Client\Model\VisitorSegments(['visitorType' => 'new']);
+        $this->assertSame('new', $segments->getVisitorType());
     }
 
     // ---- Discriminator-enum crash-class sweep (qs-13 / qs-12 regression) ----

--- a/tests/CrossSdk/rule-test-vectors.json
+++ b/tests/CrossSdk/rule-test-vectors.json
@@ -124,6 +124,29 @@
         { "value": "111222", "testAgainst": "\\d+", "negation": true, "expected": false, "note": "negated digits" },
         { "value": "USER-42", "testAgainst": "^user-[0-9]+$", "negation": false, "expected": true, "note": "case-insensitive regex" }
       ]
+    },
+    {
+      "category": "exists",
+      "method": "exists",
+      "cases": [
+        { "value": "US", "testAgainst": null, "negation": false, "expected": true, "note": "present value exists" },
+        { "value": null, "testAgainst": null, "negation": false, "expected": false, "note": "null does not exist" },
+        { "value": "", "testAgainst": null, "negation": false, "expected": false, "note": "empty string does not exist" },
+        { "value": "US", "testAgainst": null, "negation": true, "expected": false, "note": "negated present" },
+        { "value": null, "testAgainst": null, "negation": true, "expected": true, "note": "negated null" },
+        { "value": 0, "testAgainst": null, "negation": false, "expected": true, "note": "zero exists (strict)" }
+      ]
+    },
+    {
+      "category": "not_exists",
+      "method": "not_exists",
+      "cases": [
+        { "value": null, "testAgainst": null, "negation": false, "expected": true, "note": "null is not-exists" },
+        { "value": "", "testAgainst": null, "negation": false, "expected": true, "note": "empty string is not-exists" },
+        { "value": "US", "testAgainst": null, "negation": false, "expected": false, "note": "present value is not not-exists" },
+        { "value": null, "testAgainst": null, "negation": true, "expected": false, "note": "negated null" },
+        { "value": "US", "testAgainst": null, "negation": true, "expected": true, "note": "negated present" }
+      ]
     }
   ],
   "rule_evaluation": [


### PR DESCRIPTION
## Summary

Restores php-sdk ↔ js-sdk parity in two disk-verified areas (js-sdk is the reference implementation). php-sdk only — no js-sdk, python-sdk, backend, or OpenAPI changes; no generated files touched.

### 1. Add `exists` / `not_exists` / `doesNotExist` comparison operators
`packages/Utils/src/Comparisons.php` previously lacked the existence operators that js-sdk `comparisons.ts` defines. Because `RuleManager::processRuleItem()` only dispatches a `match_type` present in `get_class_methods(Comparisons::class)`, a rule with `match_type: 'exists'`/`'not_exists'` silently failed to match in PHP while matching in JS. Ported the three methods with JS strict-equality semantics (`null`/`''` => not exists; `0` exists). `not_exists` keeps the underscore so the wire `match_type` resolves; `doesNotExist` delegates to `not_exists` (faithful equivalent of JS's `static doesNotExist = not_exists`).

### 2. Align `visitor_type` segment wire-key to `visitorType`
`SegmentsKeys::VisitorType` was `'visitor_type'`; js-sdk `VISITOR_TYPE` is `'visitorType'`. Every other segment key already matched. Aligned the enum case, the hardcoded routing literal in `DataManager::filterReportSegments()`, and the two test/doc surfaces.

**Latent round-trip bug fixed (side effect):** before this change, `filterReportSegments()` routed the property under `'visitor_type'`, but the generated `VisitorSegments` model keys strictly on `'visitorType'` (`attributeMap`/`setIfExists`). So `SegmentsManager::getSegments()` → `new VisitorSegments(['visitor_type' => …])` **silently dropped the visitor-type value**. AC6 now locks the round-trip.

## Quick-spec
`ai-driven-product-dev/_bmad-output/implementation-artifacts/2026-03-13-convert-php-sdk/qs-14-php-jssdk-parity-comparisons-exists-segment-keys.md`

## Acceptance criteria coverage
- **AC1** `exists` operator parity — covered by `exists` vector group (present/null/empty/negation/strict-zero) via `testComparisonOperatorParity`.
- **AC2** `not_exists` operator parity — covered by `not_exists` vector group.
- **AC3** `doesNotExist` alias — delegates to `not_exists`.
- **AC4** RuleManager dispatch reachability — `exists`/`not_exists`/`doesNotExist` discoverable via `get_class_methods()`.
- **AC5** VisitorType segment-key alignment — `SegmentsKeys::VisitorType->value === 'visitorType'` (new parity test).
- **AC6** visitor-type segment round-trip — `new VisitorSegments(['visitorType' => 'new'])->getVisitorType() === 'new'` (new parity test).
- **AC7** structural guards updated — `testAllComparisonCategoriesPresent` now requires `exists` + `not_exists`; `testComparisonVectorMinimumCount` still passes.
- **AC8** no regression / no removed logic — no existing comparison method, enum case, or business logic removed.

## Testing (targeted, all green)
- `testComparisonOperatorParity` — 76 tests, 76 assertions OK
- `testAllComparisonCategoriesPresent` — 1 test, 12 assertions OK
- `testVisitorTypeSegmentKeySerializesAsVisitorType` — 1 test, 2 assertions OK
- `packages/Data/tests/DataManagerTest.php` — 39 tests, 85 assertions OK
- `packages/Php-sdk/tests/ContextTest.php` — 39 tests, 208 assertions OK

New comparison vectors flow through the existing `#[DataProvider]` (no copy-pasted test bodies) to respect the SonarQube duplication gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
