### PR TITLE
feat(preview): qs-02 experiment preview — debug token + preview links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Bucket visitors into experiment variations, resolve feature flags with typed var
 - [Visitor Context](#visitor-context)
 - [Experience Bucketing](#experience-bucketing)
 - [Feature Flags](#feature-flags)
+- [Experiment Preview](#experiment-preview)
 - [Conversion Tracking](#conversion-tracking)
 - [Revenue Reporting](#revenue-reporting)
 - [Force Multiple Transactions](#force-multiple-transactions)
@@ -154,6 +155,24 @@ $sdk = ConvertSDK::create([
 
 Pass any PSR-16 `CacheInterface`. When omitted, an in-memory `ArrayCache` is used (no persistence between requests).
 
+### QA debug token
+
+For QA and preview scenarios where you need the freshest possible config, pass a `debugToken`:
+
+```php
+$sdk = ConvertSDK::create([
+    'sdkKey'     => 'your-sdk-key',
+    'debugToken' => 'your-qa-debug-token',
+]);
+```
+
+When set, the SDK:
+
+- appends `debug_token=<token>` and forces `_conv_low_cache=1` on every config fetch, regardless of the project's cache level;
+- bypasses the PSR-16 config cache entirely — every request fetches config live from origin (the config cache entry is neither read nor written);
+- redacts the token from all log output (including PSR-18 client exception messages);
+- never sends the token to the tracking endpoint.
+
 **Important:** The PSR-16 cache also serves as the visitor data store. When you provide a persistent cache (Redis, Memcached, filesystem), the SDK automatically persists visitor bucketing decisions across HTTP requests. This enables conversion tracking in later requests to be correctly attributed to experiment variations. See [Data Persistence](#data-persistence) for details.
 
 ### Full configuration options
@@ -167,6 +186,7 @@ $sdk = ConvertSDK::create([
     'dataStore'           => $customStore,        // Custom data store (overrides cache for visitor data)
     'dataRefreshInterval' => 300000,              // Config cache TTL in milliseconds (default: 300000 = 5 min)
     'environment'         => 'production',        // Environment targeting
+    'debugToken'          => 'qa-debug-token',    // QA/preview: bypass config cache + force fresh fetch (see QA debug token)
 ]);
 ```
 
@@ -340,6 +360,54 @@ foreach ($features as $feature) {
 ```
 
 **Returns:** `BucketedFeature[]` — an array of all resolved features.
+
+## Experiment Preview
+
+Force a visitor context to decide a specific variation of a specific experience, bypassing every normal gate — audiences, segments, locations, environment, experience/variation status, traffic allocation, stored decisions, and the bucketing hash. This is how you render a QA/preview of a variation that a real visitor would not otherwise be bucketed into.
+
+```php
+$context = $sdk->createContext('qa-visitor');
+
+// Force the experience whose id is 100200 to decide variation 300400
+$context->setPreview('100200', '300400');
+
+// When 'homepage-redesign' is the key of experience 100200, the forced
+// variation is returned regardless of targeting or bucketing
+$variation = $context->runExperience('homepage-redesign');
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `$experienceId` | `string` | Yes | The experience id (numeric string) to preview. |
+| `$variationId` | `string` | Yes | The variation id (numeric string) to force. |
+
+**Returns:** `void`
+
+### Zero-trace guarantee
+
+Once a preview target resolves successfully, the context becomes **zero-trace for its entire lifetime**: no tracking events are sent and no visitor state is persisted for **any** experience, feature, or conversion run through that context — not just the previewed one. Preview never pollutes real experiment data, including on the shutdown flush.
+
+### Inert on bad input
+
+If the experience or variation id cannot be resolved (unknown experience, unknown variation), `setPreview()` is a no-op and the context behaves fully normally — normal bucketing and tracking resume. A preview target absent from the current config is fetched on demand via a single-experience config request (`?exp=`) and memoized for 60 seconds.
+
+### Preview links
+
+The canonical preview link format is `convert_preview={experienceId}.{variationId}`. Your application extracts the raw query-string value and parses it with `PreviewParam` — the SDK never reads request superglobals directly:
+
+```php
+use ConvertSdk\Preview\PreviewParam;
+
+$parsed = PreviewParam::parse($_GET['convert_preview'] ?? '');
+
+if ($parsed !== null) {
+    $context->setPreview($parsed['experienceId'], $parsed['variationId']);
+}
+```
+
+`PreviewParam::parse()` returns `['experienceId' => string, 'variationId' => string]` for a well-formed value, or `null` when the value is malformed.
 
 ## Conversion Tracking
 

--- a/packages/Api/src/ApiManager.php
+++ b/packages/Api/src/ApiManager.php
@@ -477,31 +477,47 @@ class ApiManager implements ApiManagerInterface
     }
 
     /**
-     * Get configuration data
+     * Build the query string for a config-fetch request, applying the shared
+     * environment/debug_token/_conv_low_cache rules (qs-02 AC1) plus any
+     * caller-supplied extra params (e.g. `exp=` for the preview fetch).
      *
-     * @return ConfigResponseData
+     * @param array<string, string> $additionalParams Extra key=>value params to append
+     * @param bool $forceLowCache Force `_conv_low_cache=1` regardless of cacheLevel/debugToken
+     * @return string The query string including the leading `?`, or '' if empty
      */
-    public function getConfig(): ConfigResponseData
+    private function buildConfigQueryString(array $additionalParams = [], bool $forceLowCache = false): string
     {
-        if ($this->loggerManager && method_exists($this->loggerManager, 'trace')) {
-            $this->loggerManager->trace('ApiManager.getConfig()');
-        }
-
         $hasDebugToken = $this->debugToken !== null && $this->debugToken !== '';
 
         $params = [];
         if ($this->environment) {
             $params[] = 'environment=' . urlencode($this->environment);
         }
+        foreach ($additionalParams as $key => $value) {
+            $params[] = $key . '=' . urlencode((string) $value);
+        }
         if ($hasDebugToken) {
             // Forced regardless of network.cacheLevel — qs-02 AC1.
             $params[] = 'debug_token=' . urlencode((string) $this->debugToken);
         }
-        if ($this->cacheLevel === 'low' || $hasDebugToken) {
+        if ($forceLowCache || $this->cacheLevel === 'low' || $hasDebugToken) {
             $params[] = '_conv_low_cache=1';
         }
-        $query = $params !== [] ? '?' . implode('&', $params) : '';
 
+        return $params !== [] ? '?' . implode('&', $params) : '';
+    }
+
+    /**
+     * Shared GET/parse/log/error-handling body for the two config-fetch entry
+     * points ({@see getConfig()} and {@see getConfigForExperience()}) — only
+     * the query string and the log context label differ between them.
+     *
+     * @param string $query The query string (including leading `?`, or '')
+     * @param string $logContext Log context label (e.g. 'ApiManager.getConfig()')
+     * @return ConfigResponseData
+     */
+    private function fetchConfigFromEndpoint(string $query, string $logContext): ConfigResponseData
+    {
         try {
             $response = $this->request(
                 'GET',
@@ -515,7 +531,7 @@ class ApiManager implements ApiManagerInterface
             if ($statusCode < 200 || $statusCode >= 300) {
                 $url = $this->configEndpoint . "/config/{$this->sdkKey}";
                 if ($this->loggerManager) {
-                    $this->loggerManager->error('ApiManager.getConfig()', [
+                    $this->loggerManager->error($logContext, [
                         'endpoint' => $this->redactDebugTokenForLog($url . $query),
                         'status' => 'error',
                         'httpStatus' => $statusCode,
@@ -537,7 +553,7 @@ class ApiManager implements ApiManagerInterface
 
             if ($this->loggerManager) {
                 $project = $configData->getProject();
-                $this->loggerManager->debug('ApiManager.getConfig()', [
+                $this->loggerManager->debug($logContext, [
                     'endpoint' => $this->redactDebugTokenForLog($this->configEndpoint . "/config/{$this->sdkKey}" . $query),
                     'status' => 'success',
                     'httpStatus' => $statusCode,
@@ -550,7 +566,7 @@ class ApiManager implements ApiManagerInterface
             return $configData;
         } catch (ClientExceptionInterface $e) {
             if ($this->loggerManager) {
-                $this->loggerManager->error('ApiManager.getConfig()', [
+                $this->loggerManager->error($logContext, [
                     'endpoint' => $this->redactDebugTokenForLog($this->configEndpoint . "/config/{$this->sdkKey}" . $query),
                     'status' => 'error',
                     'error' => $e->getMessage(),
@@ -564,5 +580,43 @@ class ApiManager implements ApiManagerInterface
                 $e
             );
         }
+    }
+
+    /**
+     * Get configuration data
+     *
+     * @return ConfigResponseData
+     */
+    public function getConfig(): ConfigResponseData
+    {
+        if ($this->loggerManager && method_exists($this->loggerManager, 'trace')) {
+            $this->loggerManager->trace('ApiManager.getConfig()');
+        }
+
+        $query = $this->buildConfigQueryString();
+
+        return $this->fetchConfigFromEndpoint($query, 'ApiManager.getConfig()');
+    }
+
+    /**
+     * Get configuration data scoped to a single experience (qs-02 capability B
+     * preview input — AC4). Forces `exp={experienceId}` and `_conv_low_cache=1`
+     * onto the config-fetch URL regardless of `network.cacheLevel`, plus
+     * `debug_token=` when configured — this is how the SDK resolves a preview
+     * target that is absent from the current config (draft/paused/other
+     * environment).
+     *
+     * @param string $experienceId The experience id to inject via `exp=`
+     * @return ConfigResponseData
+     */
+    public function getConfigForExperience(string $experienceId): ConfigResponseData
+    {
+        if ($this->loggerManager && method_exists($this->loggerManager, 'trace')) {
+            $this->loggerManager->trace('ApiManager.getConfigForExperience()', ['experienceId' => $experienceId]);
+        }
+
+        $query = $this->buildConfigQueryString(['exp' => $experienceId], true);
+
+        return $this->fetchConfigFromEndpoint($query, 'ApiManager.getConfigForExperience()');
     }
 }

--- a/packages/Api/src/ApiManager.php
+++ b/packages/Api/src/ApiManager.php
@@ -455,13 +455,19 @@ class ApiManager implements ApiManagerInterface
     }
 
     /**
-     * Redact the configured debugToken (qs-02 AC3 — token hygiene) from a
-     * log-only string, e.g. a config-fetch endpoint URL that carries
-     * `debug_token=<value>` in its query string. Only used for values passed
-     * to the logger — never affects the actual request URL.
+     * Redact the `debug_token` query-param value (qs-02 AC3 — token hygiene)
+     * from a log-only string, e.g. a config-fetch endpoint URL or an
+     * exception message that carries `debug_token=<value>` in its query
+     * string. Encoding-agnostic: matches the value regardless of whether it
+     * was produced by `urlencode()`, `rawurlencode()`, left decoded, or
+     * mangled by an arbitrary PSR-18 client — the exception message passed
+     * in here originates from whatever HTTP client is plugged in, which is
+     * not guaranteed to encode (or even include) the URL the same way this
+     * SDK built it. Only used for values passed to the logger/rethrown
+     * exception — never affects the actual request URL.
      *
      * @param string $value The string to redact before logging
-     * @return string The value with the token masked, if present
+     * @return string The value with the token value masked, if present
      */
     private function redactDebugTokenForLog(string $value): string
     {
@@ -469,9 +475,9 @@ class ApiManager implements ApiManagerInterface
             return $value;
         }
 
-        return str_replace(
-            'debug_token=' . urlencode($this->debugToken),
-            'debug_token=***REDACTED***',
+        return (string) preg_replace(
+            '/(debug_token=)[^&\s]*/i',
+            '${1}***REDACTED***',
             $value
         );
     }

--- a/packages/Api/src/ApiManager.php
+++ b/packages/Api/src/ApiManager.php
@@ -565,17 +565,24 @@ class ApiManager implements ApiManagerInterface
 
             return $configData;
         } catch (ClientExceptionInterface $e) {
+            // qs-02 AC3 — PSR-18 client exceptions (e.g. Guzzle's ConnectException
+            // on DNS/TLS/timeout failures) commonly append " for <full URI>" to
+            // getMessage(), which carries the same debug_token=<value> query
+            // param as the sibling `endpoint` log field below. Redact once here
+            // so neither the log entry nor the rethrown RuntimeException leaks it.
+            $safeMessage = $this->redactDebugTokenForLog($e->getMessage());
+
             if ($this->loggerManager) {
                 $this->loggerManager->error($logContext, [
                     'endpoint' => $this->redactDebugTokenForLog($this->configEndpoint . "/config/{$this->sdkKey}" . $query),
                     'status' => 'error',
-                    'error' => $e->getMessage(),
+                    'error' => $safeMessage,
                     'code' => method_exists($e, 'getCode') ? $e->getCode() : null,
                 ]);
             }
 
             throw new \RuntimeException(
-                "Failed to fetch config from {$this->configEndpoint}/config/{$this->sdkKey}: HTTP error - {$e->getMessage()}",
+                "Failed to fetch config from {$this->configEndpoint}/config/{$this->sdkKey}: HTTP error - {$safeMessage}",
                 (int)$e->getCode(),
                 $e
             );

--- a/packages/Api/src/ApiManager.php
+++ b/packages/Api/src/ApiManager.php
@@ -111,6 +111,14 @@ class ApiManager implements ApiManagerInterface
     /** @var string Cache level setting */
     private string $cacheLevel;
 
+    /**
+     * Optional QA/preview debug token (qs-02 capability A). When set, forces
+     * `debug_token=<value>` and `_conv_low_cache=1` onto every config-fetch
+     * URL, regardless of `network.cacheLevel`. Never sent to the track
+     * endpoint; redacted from log output via {@see redactDebugTokenForLog()}.
+     */
+    private ?string $debugToken = null;
+
     /** @var callable Mapper function for data transformation */
     private mixed $mapper;
 
@@ -188,6 +196,7 @@ class ApiManager implements ApiManagerInterface
         $this->cacheLevel = $config && $config->getNetwork() && isset($config->getNetwork()['cacheLevel'])
             ? (string) $config->getNetwork()['cacheLevel']
             : '';
+        $this->debugToken = $config ? $config->getDebugToken() : null;
 
         $this->httpClient = $httpClient ?? Psr18ClientDiscovery::find();
         $this->requestFactory = $requestFactory ?? Psr17FactoryDiscovery::findRequestFactory();
@@ -446,6 +455,28 @@ class ApiManager implements ApiManagerInterface
     }
 
     /**
+     * Redact the configured debugToken (qs-02 AC3 — token hygiene) from a
+     * log-only string, e.g. a config-fetch endpoint URL that carries
+     * `debug_token=<value>` in its query string. Only used for values passed
+     * to the logger — never affects the actual request URL.
+     *
+     * @param string $value The string to redact before logging
+     * @return string The value with the token masked, if present
+     */
+    private function redactDebugTokenForLog(string $value): string
+    {
+        if ($this->debugToken === null || $this->debugToken === '') {
+            return $value;
+        }
+
+        return str_replace(
+            'debug_token=' . urlencode($this->debugToken),
+            'debug_token=***REDACTED***',
+            $value
+        );
+    }
+
+    /**
      * Get configuration data
      *
      * @return ConfigResponseData
@@ -456,19 +487,20 @@ class ApiManager implements ApiManagerInterface
             $this->loggerManager->trace('ApiManager.getConfig()');
         }
 
-        $query = '';
-        if ($this->cacheLevel === 'low' || $this->environment) {
-            $query = '?';
-        }
+        $hasDebugToken = $this->debugToken !== null && $this->debugToken !== '';
+
+        $params = [];
         if ($this->environment) {
-            $query .= 'environment=' . urlencode($this->environment);
+            $params[] = 'environment=' . urlencode($this->environment);
         }
-        if ($this->cacheLevel === 'low') {
-            if ($query !== '?') {
-                $query .= '&';
-            }
-            $query .= '_conv_low_cache=1';
+        if ($hasDebugToken) {
+            // Forced regardless of network.cacheLevel — qs-02 AC1.
+            $params[] = 'debug_token=' . urlencode((string) $this->debugToken);
         }
+        if ($this->cacheLevel === 'low' || $hasDebugToken) {
+            $params[] = '_conv_low_cache=1';
+        }
+        $query = $params !== [] ? '?' . implode('&', $params) : '';
 
         try {
             $response = $this->request(
@@ -484,7 +516,7 @@ class ApiManager implements ApiManagerInterface
                 $url = $this->configEndpoint . "/config/{$this->sdkKey}";
                 if ($this->loggerManager) {
                     $this->loggerManager->error('ApiManager.getConfig()', [
-                        'endpoint' => $url . $query,
+                        'endpoint' => $this->redactDebugTokenForLog($url . $query),
                         'status' => 'error',
                         'httpStatus' => $statusCode,
                         'error' => "HTTP {$statusCode}",
@@ -506,7 +538,7 @@ class ApiManager implements ApiManagerInterface
             if ($this->loggerManager) {
                 $project = $configData->getProject();
                 $this->loggerManager->debug('ApiManager.getConfig()', [
-                    'endpoint' => $this->configEndpoint . "/config/{$this->sdkKey}" . $query,
+                    'endpoint' => $this->redactDebugTokenForLog($this->configEndpoint . "/config/{$this->sdkKey}" . $query),
                     'status' => 'success',
                     'httpStatus' => $statusCode,
                     'accountId' => $configData->getAccountId() ?? 'unknown',
@@ -519,7 +551,7 @@ class ApiManager implements ApiManagerInterface
         } catch (ClientExceptionInterface $e) {
             if ($this->loggerManager) {
                 $this->loggerManager->error('ApiManager.getConfig()', [
-                    'endpoint' => $this->configEndpoint . "/config/{$this->sdkKey}" . $query,
+                    'endpoint' => $this->redactDebugTokenForLog($this->configEndpoint . "/config/{$this->sdkKey}" . $query),
                     'status' => 'error',
                     'error' => $e->getMessage(),
                     'code' => method_exists($e, 'getCode') ? $e->getCode() : null,

--- a/packages/Api/src/Interfaces/ApiManagerInterface.php
+++ b/packages/Api/src/Interfaces/ApiManagerInterface.php
@@ -79,4 +79,14 @@ interface ApiManagerInterface
      * @return ConfigResponseData
      */
     public function getConfig(): ConfigResponseData;
+
+    /**
+     * Get configuration data scoped to a single experience via `exp=` (qs-02
+     * capability B preview input — AC4). Forces `_conv_low_cache=1` regardless
+     * of `network.cacheLevel`, plus `debug_token=` when configured.
+     *
+     * @param string $experienceId The experience id to inject via `exp=`
+     * @return ConfigResponseData
+     */
+    public function getConfigForExperience(string $experienceId): ConfigResponseData;
 }

--- a/packages/Api/tests/ApiManagerDebugTokenTest.php
+++ b/packages/Api/tests/ApiManagerDebugTokenTest.php
@@ -38,6 +38,14 @@ class ApiManagerDebugTokenTest extends TestCase
     private const BATCH_SIZE = 2;
     private const SECRET_TOKEN = 'qa-debug-token-xyz789';
 
+    /**
+     * Contains a space so its urlencode() and rawurlencode() representations
+     * genuinely differ (`+` vs `%20`) — required to prove the encoding-agnostic
+     * redaction fix, since the old `str_replace('debug_token=' . urlencode(...))`
+     * approach only ever matched the urlencode() shape.
+     */
+    private const ENCODING_TEST_TOKEN = 'qa debug token xyz';
+
     private MockHttpClient $mockHttpClient;
     private Psr17Factory $psr17Factory;
     /** @var EventManagerInterface&\PHPUnit\Framework\MockObject\MockObject */
@@ -364,6 +372,115 @@ class ApiManagerDebugTokenTest extends TestCase
             self::SECRET_TOKEN,
             $thrown->getMessage(),
             'Secret token leaked into the rethrown exception message'
+        );
+    }
+
+    /**
+     * Build a PSR-18 network-level exception whose message embeds
+     * `debug_token=<tokenAsItAppearsInUrl>&other=param` — the caller controls
+     * exactly how the token is represented in the message (rawurlencode()'d,
+     * fully decoded/un-encoded, etc.) so the redaction fix can be proven
+     * encoding-agnostic rather than coupled to `urlencode()` output.
+     */
+    private function buildNetworkExceptionWithEncodedDebugToken(
+        string $tokenAsItAppearsInUrl
+    ): \Http\Client\Exception\NetworkException {
+        $leakingUrl = self::HOST . ':' . self::PORT
+            . '/config/?environment=staging&debug_token=' . $tokenAsItAppearsInUrl . '&other=param';
+
+        return new \Http\Client\Exception\NetworkException(
+            'cURL error 6: Could not resolve host: localhost for ' . $leakingUrl,
+            $this->psr17Factory->createRequest('GET', self::HOST . ':' . self::PORT . '/config/')
+        );
+    }
+
+    /**
+     * Two representations of {@see ENCODING_TEST_TOKEN} that a plugged-in
+     * PSR-18 client could plausibly embed in an exception message: Guzzle
+     * (and most HTTP clients) rawurlencode() query values, while a client
+     * that logs/presents a decoded URL for readability would show the value
+     * fully un-encoded. Both must be redacted regardless of which shows up.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function debugTokenEncodingProvider(): array
+    {
+        return [
+            'rawurlencoded (spaces as %20)' => [rawurlencode(self::ENCODING_TEST_TOKEN)],
+            'un-encoded / decoded' => [self::ENCODING_TEST_TOKEN],
+        ];
+    }
+
+    /**
+     * AC3 — token hygiene must hold regardless of how the plugged-in PSR-18
+     * client encoded (or didn't encode) the token in its own exception
+     * message. Before the fix, `redactDebugTokenForLog()` matched only the
+     * exact `urlencode($this->debugToken)` byte sequence — since
+     * `urlencode('qa debug token xyz')` produces `qa+debug+token+xyz`, it
+     * would silently no-op against a rawurlencode()'d (`%20`) or fully
+     * decoded (raw space) representation, leaking the token verbatim into
+     * both the log payload and the rethrown RuntimeException. The
+     * regex-based fix redacts `debug_token=<value>` regardless of encoding,
+     * while leaving the surrounding message (prefix and the trailing
+     * `&other=param`) untouched.
+     */
+    #[DataProvider('debugTokenEncodingProvider')]
+    public function testDebugTokenRedactionIsEncodingAgnostic(string $tokenAsItAppearsInUrl): void
+    {
+        $captured = [];
+        $this->spyAllLogCalls($captured);
+
+        $apiManager = $this->buildApiManager(['debugToken' => self::ENCODING_TEST_TOKEN]);
+        $this->mockHttpClient->addException(
+            $this->buildNetworkExceptionWithEncodedDebugToken($tokenAsItAppearsInUrl)
+        );
+
+        $thrown = null;
+        try {
+            $apiManager->getConfig();
+        } catch (\RuntimeException $e) {
+            $thrown = $e;
+        }
+
+        $this->assertNotNull($thrown, 'Expected getConfig() to rethrow a RuntimeException');
+        $this->assertNotEmpty($captured, 'Expected at least one log call to inspect');
+
+        $serializedLogs = (string) json_encode($captured, JSON_PARTIAL_OUTPUT_ON_ERROR);
+
+        // The exact on-the-wire representation the exception message carried
+        // must be gone — this is what proves the fix works regardless of
+        // encoding (for the decoded row, this representation IS the full
+        // secret; for the rawurlencoded row, it's the %20-encoded value).
+        $this->assertStringNotContainsString(
+            $tokenAsItAppearsInUrl,
+            $serializedLogs,
+            'Debug token representation leaked into a log payload'
+        );
+        $this->assertStringNotContainsString(
+            $tokenAsItAppearsInUrl,
+            $thrown->getMessage(),
+            'Debug token representation leaked into the rethrown exception message'
+        );
+
+        // The full configured secret must never appear verbatim either way.
+        $this->assertNoSecretLeak($captured, self::ENCODING_TEST_TOKEN);
+        $this->assertStringNotContainsString(
+            self::ENCODING_TEST_TOKEN,
+            $thrown->getMessage(),
+            'Full secret token leaked into the rethrown exception message'
+        );
+
+        // Surrounding message content — before `debug_token=` and after the
+        // redacted value — must be preserved untouched.
+        $this->assertStringContainsString(
+            'Could not resolve host',
+            $thrown->getMessage(),
+            'Message content preceding debug_token= must be preserved'
+        );
+        $this->assertStringContainsString(
+            '&other=param',
+            $thrown->getMessage(),
+            'Message content following the redacted value must be preserved'
         );
     }
 }

--- a/packages/Api/tests/ApiManagerDebugTokenTest.php
+++ b/packages/Api/tests/ApiManagerDebugTokenTest.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConvertSdk\Tests;
+
+use ConvertSdk\ApiManager;
+use ConvertSdk\Config\DefaultConfig;
+use ConvertSdk\Event\Interfaces\EventManagerInterface;
+use ConvertSdk\Interfaces\LogManagerInterface;
+use ConvertSdk\Utils\ObjectUtils;
+use Http\Mock\Client as MockHttpClient;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\Response;
+use OpenAPI\Client\Config;
+use OpenAPI\Client\Model\ConfigResponseData;
+use OpenAPI\Client\Model\VisitorTrackingEvents;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * qs-02 capability (A) `debugToken` config option.
+ *
+ * Covers:
+ * - AC1 (transport): config-fetch URL carries `debug_token=<value>` AND
+ *   `_conv_low_cache=1` when set, forced regardless of `network.cacheLevel`;
+ *   neither when unset (unless cacheLevel=low already adds the low-cache flag).
+ * - AC3 (token hygiene): the token never reaches the track-endpoint payload
+ *   nor any log call in clear text.
+ *
+ * @see ../../../../ai-driven-product-dev/_bmad-output/planning-artifacts/2026-03-13-convert-php-sdk/qs-02-experiment-preview.md
+ */
+class ApiManagerDebugTokenTest extends TestCase
+{
+    private const HOST = 'http://localhost';
+    private const PORT = 8091;
+    private const BATCH_SIZE = 2;
+    private const SECRET_TOKEN = 'qa-debug-token-xyz789';
+
+    private MockHttpClient $mockHttpClient;
+    private Psr17Factory $psr17Factory;
+    /** @var EventManagerInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private $eventManagerMock;
+    /** @var LogManagerInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private $loggerManagerMock;
+
+    protected function setUp(): void
+    {
+        $this->mockHttpClient = new MockHttpClient();
+        $this->psr17Factory = new Psr17Factory();
+        $this->eventManagerMock = $this->createMock(EventManagerInterface::class);
+        $this->loggerManagerMock = $this->createMock(LogManagerInterface::class);
+    }
+
+    /**
+     * Build a Config merging the shared test fixture + SDK defaults + per-test
+     * overrides, mirroring ApiManagerTest's fixture assembly so the two test
+     * classes stay consistent.
+     *
+     * @param array<string, mixed> $overrides
+     */
+    private function buildConfig(array $overrides = []): Config
+    {
+        $testConfig = json_decode((string) file_get_contents(__DIR__ . '/test-config.json'), true);
+        $defaultConfig = DefaultConfig::getDefault();
+        $mergedConfig = ObjectUtils::objectDeepMerge($testConfig, $defaultConfig);
+
+        $baseOverrides = [
+            'api' => [
+                'endpoint' => [
+                    'config' => self::HOST . ':' . self::PORT,
+                    'track'  => self::HOST . ':' . self::PORT,
+                ],
+            ],
+            'events' => [
+                'batch_size' => self::BATCH_SIZE,
+            ],
+            'mapper' => null,
+        ];
+        $layeredOverrides = ObjectUtils::objectDeepMerge($baseOverrides, $overrides);
+        $finalConfig = ObjectUtils::objectDeepMerge($mergedConfig, $layeredOverrides);
+
+        if (isset($finalConfig['sdkKey'])) {
+            unset($finalConfig['sdkKey']);
+        }
+        $finalConfig['data'] = new ConfigResponseData($finalConfig['data']);
+
+        return new Config($finalConfig);
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    private function buildApiManager(array $overrides = []): ApiManager
+    {
+        return new ApiManager(
+            $this->buildConfig($overrides),
+            $this->eventManagerMock,
+            $this->loggerManagerMock,
+            $this->mockHttpClient,
+            $this->psr17Factory,
+            $this->psr17Factory
+        );
+    }
+
+    private function queueSuccessfulConfigResponse(): void
+    {
+        $this->mockHttpClient->addResponse(
+            new Response(200, ['Content-Type' => 'application/json'], (string) json_encode([
+                'data' => [
+                    'account_id' => '999',
+                    'project' => ['id' => '888', 'key' => 'test-project'],
+                    'experiences' => [],
+                    'features' => [],
+                    'segments' => [],
+                    'audiences' => [],
+                    'goals' => [],
+                    'locations' => [],
+                ],
+            ]))
+        );
+    }
+
+    /**
+     * Stub every logger method to capture its arguments into $captured,
+     * so AC3 tests can assert the secret never appears in any log call
+     * regardless of level.
+     *
+     * @param array<int, array{0: string, 1: array<int, mixed>}> $captured
+     */
+    private function spyAllLogCalls(array &$captured): void
+    {
+        foreach (['trace', 'debug', 'info', 'warn', 'error'] as $method) {
+            $this->loggerManagerMock->method($method)
+                ->willReturnCallback(function (...$args) use (&$captured, $method): void {
+                    $captured[] = [$method, $args];
+                });
+        }
+    }
+
+    /**
+     * @param array<int, array{0: string, 1: array<int, mixed>}> $captured
+     */
+    private function assertNoSecretLeak(array $captured, string $secret): void
+    {
+        $serialized = json_encode($captured, JSON_PARTIAL_OUTPUT_ON_ERROR);
+        $this->assertIsString($serialized);
+        $this->assertStringNotContainsString($secret, $serialized, 'Secret token leaked into a log payload');
+    }
+
+    /**
+     * @return array<string, array{0: ?string, 1: string, 2: bool, 3: bool}>
+     */
+    public static function debugTokenUrlProvider(): array
+    {
+        return [
+            'debugToken set, default cacheLevel — both params forced' => [
+                self::SECRET_TOKEN, 'default', true, true,
+            ],
+            'debugToken unset, default cacheLevel — neither param' => [
+                null, 'default', false, false,
+            ],
+            'debugToken unset, cacheLevel=low — only low-cache param (regression, today\'s behavior)' => [
+                null, 'low', false, true,
+            ],
+            'debugToken set, cacheLevel=low — both, forced regardless' => [
+                self::SECRET_TOKEN, 'low', true, true,
+            ],
+        ];
+    }
+
+    /**
+     * AC1 — debugToken transport.
+     */
+    #[DataProvider('debugTokenUrlProvider')]
+    public function testDebugTokenUrlTransport(
+        ?string $debugToken,
+        string $cacheLevel,
+        bool $expectDebugTokenParam,
+        bool $expectLowCacheParam
+    ): void {
+        $overrides = ['network' => ['cacheLevel' => $cacheLevel]];
+        if ($debugToken !== null) {
+            $overrides['debugToken'] = $debugToken;
+        }
+
+        $apiManager = $this->buildApiManager($overrides);
+        $this->queueSuccessfulConfigResponse();
+
+        $apiManager->getConfig();
+
+        $sentUri = (string) $this->mockHttpClient->getLastRequest()->getUri();
+
+        if ($expectDebugTokenParam) {
+            $this->assertStringContainsString('debug_token=' . $debugToken, $sentUri);
+        } else {
+            $this->assertStringNotContainsString('debug_token=', $sentUri);
+        }
+
+        if ($expectLowCacheParam) {
+            $this->assertStringContainsString('_conv_low_cache=1', $sentUri);
+        } else {
+            $this->assertStringNotContainsString('_conv_low_cache=1', $sentUri);
+        }
+    }
+
+    /**
+     * AC3 — token hygiene: never sent to the track endpoint.
+     */
+    #[Test]
+    public function debugTokenNeverAppearsInTrackEndpointPayload(): void
+    {
+        $apiManager = $this->buildApiManager(['debugToken' => self::SECRET_TOKEN]);
+
+        $requestData = new VisitorTrackingEvents([
+            'eventType' => 'bucketing',
+            'data' => ['experienceId' => '11', 'variationId' => '12'],
+        ]);
+
+        $this->mockHttpClient->addResponse(
+            new Response(200, ['Content-Type' => 'application/json'], '{}')
+        );
+
+        for ($i = 1; $i <= self::BATCH_SIZE; $i++) {
+            $apiManager->enqueue("VID$i", $requestData);
+        }
+
+        $sentRequest = $this->mockHttpClient->getLastRequest();
+        $this->assertNotNull($sentRequest);
+        $this->assertStringContainsString('/track/', (string) $sentRequest->getUri());
+
+        $body = (string) $sentRequest->getBody();
+        $this->assertStringNotContainsString(self::SECRET_TOKEN, $body);
+        $this->assertStringNotContainsString('debug_token', $body);
+    }
+
+    /**
+     * AC3 — token hygiene: never logged in clear on a successful config fetch.
+     */
+    #[Test]
+    public function debugTokenNeverAppearsInConfigFetchSuccessLogs(): void
+    {
+        $captured = [];
+        $this->spyAllLogCalls($captured);
+
+        $apiManager = $this->buildApiManager(['debugToken' => self::SECRET_TOKEN]);
+        $this->queueSuccessfulConfigResponse();
+
+        $apiManager->getConfig();
+
+        $this->assertNotEmpty($captured, 'Expected at least one log call to inspect');
+        $this->assertNoSecretLeak($captured, self::SECRET_TOKEN);
+    }
+
+    /**
+     * AC3 — token hygiene: never logged in clear when the config fetch fails
+     * (bad HTTP status) — this is the codepath most likely to leak the raw
+     * query string via the 'endpoint' log field.
+     */
+    #[Test]
+    public function debugTokenNeverAppearsInConfigFetchBadStatusLogs(): void
+    {
+        $captured = [];
+        $this->spyAllLogCalls($captured);
+
+        $apiManager = $this->buildApiManager(['debugToken' => self::SECRET_TOKEN]);
+        $this->mockHttpClient->addResponse(
+            new Response(500, ['Content-Type' => 'application/json'], '{"error":"internal"}')
+        );
+
+        try {
+            $apiManager->getConfig();
+        } catch (\RuntimeException $e) {
+            // Expected — the failure path also logs; the assertion below still applies.
+        }
+
+        $this->assertNotEmpty($captured, 'Expected at least one log call to inspect');
+        $this->assertNoSecretLeak($captured, self::SECRET_TOKEN);
+    }
+
+    /**
+     * AC3 — token hygiene: never logged in clear when the HTTP client throws
+     * a network-level exception (the other logging codepath in getConfig()).
+     */
+    #[Test]
+    public function debugTokenNeverAppearsInConfigFetchNetworkErrorLogs(): void
+    {
+        $captured = [];
+        $this->spyAllLogCalls($captured);
+
+        $apiManager = $this->buildApiManager(['debugToken' => self::SECRET_TOKEN]);
+        $this->mockHttpClient->addException(
+            new \Http\Client\Exception\NetworkException(
+                'Connection refused',
+                $this->psr17Factory->createRequest('GET', 'http://localhost')
+            )
+        );
+
+        try {
+            $apiManager->getConfig();
+        } catch (\RuntimeException $e) {
+            // Expected — getConfig() wraps and rethrows; the assertion below still applies.
+        }
+
+        $this->assertNotEmpty($captured, 'Expected at least one log call to inspect');
+        $this->assertNoSecretLeak($captured, self::SECRET_TOKEN);
+    }
+}

--- a/packages/Api/tests/ApiManagerDebugTokenTest.php
+++ b/packages/Api/tests/ApiManagerDebugTokenTest.php
@@ -280,8 +280,34 @@ class ApiManagerDebugTokenTest extends TestCase
     }
 
     /**
-     * AC3 — token hygiene: never logged in clear when the HTTP client throws
-     * a network-level exception (the other logging codepath in getConfig()).
+     * Build a PSR-18 network-level exception whose message embeds the full
+     * config-fetch URL — including `debug_token=<value>` — mirroring how
+     * Guzzle's ConnectException/RequestException append `" for <URI>"` to
+     * connection/DNS/TLS/timeout failures. This is the shape that actually
+     * exercises the AC3 leak: a message-less exception (e.g. bare
+     * "Connection refused") never touches the token and passes trivially
+     * regardless of whether redaction is applied.
+     */
+    private function buildNetworkExceptionWithLeakingUrl(): \Http\Client\Exception\NetworkException
+    {
+        $leakingUrl = self::HOST . ':' . self::PORT
+            . '/config/?environment=staging&debug_token=' . self::SECRET_TOKEN . '&_conv_low_cache=1';
+
+        return new \Http\Client\Exception\NetworkException(
+            'cURL error 6: Could not resolve host: localhost for ' . $leakingUrl,
+            $this->psr17Factory->createRequest('GET', $leakingUrl)
+        );
+    }
+
+    /**
+     * AC3 — token hygiene: never logged in clear, and never present in the
+     * rethrown exception's message, when the HTTP client throws a
+     * network-level exception whose own message embeds the full config URL
+     * (Guzzle's ConnectException/RequestException behavior). This is the
+     * codepath that leaked before the fix: `redactDebugTokenForLog()` was
+     * applied to the sibling `endpoint` log field but not to `$e->getMessage()`
+     * itself, which is both logged raw and interpolated raw into the
+     * rethrown RuntimeException.
      */
     #[Test]
     public function debugTokenNeverAppearsInConfigFetchNetworkErrorLogs(): void
@@ -290,20 +316,54 @@ class ApiManagerDebugTokenTest extends TestCase
         $this->spyAllLogCalls($captured);
 
         $apiManager = $this->buildApiManager(['debugToken' => self::SECRET_TOKEN]);
-        $this->mockHttpClient->addException(
-            new \Http\Client\Exception\NetworkException(
-                'Connection refused',
-                $this->psr17Factory->createRequest('GET', 'http://localhost')
-            )
-        );
+        $this->mockHttpClient->addException($this->buildNetworkExceptionWithLeakingUrl());
 
+        $thrown = null;
         try {
             $apiManager->getConfig();
         } catch (\RuntimeException $e) {
-            // Expected — getConfig() wraps and rethrows; the assertion below still applies.
+            $thrown = $e;
         }
 
+        $this->assertNotNull($thrown, 'Expected getConfig() to rethrow a RuntimeException');
         $this->assertNotEmpty($captured, 'Expected at least one log call to inspect');
         $this->assertNoSecretLeak($captured, self::SECRET_TOKEN);
+        $this->assertStringNotContainsString(
+            self::SECRET_TOKEN,
+            $thrown->getMessage(),
+            'Secret token leaked into the rethrown exception message'
+        );
+    }
+
+    /**
+     * AC3/AC4 symmetry — the preview-fetch entry point
+     * (`getConfigForExperience()`, used by `PreviewResolver`) shares the same
+     * `fetchConfigFromEndpoint()` error-handling body as `getConfig()`, so it
+     * must be equally immune to the network-exception leak.
+     */
+    #[Test]
+    public function debugTokenNeverAppearsInConfigForExperienceNetworkErrorLogs(): void
+    {
+        $captured = [];
+        $this->spyAllLogCalls($captured);
+
+        $apiManager = $this->buildApiManager(['debugToken' => self::SECRET_TOKEN]);
+        $this->mockHttpClient->addException($this->buildNetworkExceptionWithLeakingUrl());
+
+        $thrown = null;
+        try {
+            $apiManager->getConfigForExperience('exp-1');
+        } catch (\RuntimeException $e) {
+            $thrown = $e;
+        }
+
+        $this->assertNotNull($thrown, 'Expected getConfigForExperience() to rethrow a RuntimeException');
+        $this->assertNotEmpty($captured, 'Expected at least one log call to inspect');
+        $this->assertNoSecretLeak($captured, self::SECRET_TOKEN);
+        $this->assertStringNotContainsString(
+            self::SECRET_TOKEN,
+            $thrown->getMessage(),
+            'Secret token leaked into the rethrown exception message'
+        );
     }
 }

--- a/packages/Api/tests/ApiManagerPreviewFetchTest.php
+++ b/packages/Api/tests/ApiManagerPreviewFetchTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConvertSdk\Tests;
+
+use ConvertSdk\ApiManager;
+use ConvertSdk\Event\Interfaces\EventManagerInterface;
+use Http\Mock\Client as MockHttpClient;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\Response;
+use OpenAPI\Client\Config;
+use OpenAPI\Client\Model\ConfigResponseData;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * qs-02 capability (B) preview input — the `?exp=` origin fetch at the
+ * ApiManager unit level.
+ *
+ * Contract §2 (resolution): "if experienceId is not in the current config,
+ * fetch the config with exp={experienceId} and _conv_low_cache=1 appended
+ * (plus debug_token if configured) and use the response for this context."
+ *
+ * This covers the URL-construction slice of AC4 ("forced decision ... delivered
+ * only via the ?exp= fetch") in isolation from bucketing/rule/context concerns.
+ * Full-chain forcing/bypass/zero-trace/isolation/memoization behavior is
+ * covered by ContextPreviewTest (packages/Php-sdk/tests/Preview/).
+ *
+ * RED-phase note (qs-02 PHP-2, TDD RED): `ApiManager::getConfigForExperience()`
+ * does not exist yet. Every test below is expected to fail with
+ * `Error: Call to undefined method ConvertSdk\ApiManager::getConfigForExperience()`
+ * until the PHP-2 GREEN implementation lands.
+ *
+ * @see ../../../../ai-driven-product-dev/_bmad-output/planning-artifacts/2026-03-13-convert-php-sdk/qs-02-experiment-preview.md
+ */
+class ApiManagerPreviewFetchTest extends TestCase
+{
+    private const HOST = 'http://localhost';
+    private const PORT = 8092;
+    private const EXPERIENCE_ID = '9001';
+    private const DEBUG_TOKEN = 'qa-debug-token-xyz789';
+
+    private MockHttpClient $mockHttpClient;
+    private Psr17Factory $psr17Factory;
+
+    protected function setUp(): void
+    {
+        $this->mockHttpClient = new MockHttpClient();
+        $this->psr17Factory = new Psr17Factory();
+    }
+
+    private function buildApiManager(?string $debugToken = null): ApiManager
+    {
+        $config = [
+            'sdkKey' => 'test-sdk-key',
+            'environment' => 'production',
+            'api' => [
+                'endpoint' => [
+                    'config' => self::HOST . ':' . self::PORT,
+                    'track' => self::HOST . ':' . self::PORT,
+                ],
+            ],
+        ];
+        if ($debugToken !== null) {
+            $config['debugToken'] = $debugToken;
+        }
+
+        return new ApiManager(
+            new Config($config),
+            $this->createMock(EventManagerInterface::class),
+            null,
+            $this->mockHttpClient,
+            $this->psr17Factory,
+            $this->psr17Factory
+        );
+    }
+
+    private function queueExpConfigResponse(): void
+    {
+        $this->mockHttpClient->addResponse(new Response(200, ['Content-Type' => 'application/json'], (string) json_encode([
+            'data' => [
+                'account_id' => '999',
+                'project' => ['id' => '888'],
+                'experiences' => [
+                    ['id' => self::EXPERIENCE_ID, 'key' => 'preview-target', 'status' => 'draft', 'variations' => []],
+                ],
+            ],
+        ])));
+    }
+
+    /**
+     * @return array<string, array{0: ?string}>
+     */
+    public static function debugTokenProvider(): array
+    {
+        return [
+            'no debugToken configured' => [null],
+            'debugToken configured' => [self::DEBUG_TOKEN],
+        ];
+    }
+
+    /**
+     * AC4 (fetch contract): the exp= fetch always forces `exp={id}` and
+     * `_conv_low_cache=1`, plus `debug_token=` only when configured — reusing
+     * the same URL surface PHP-1 built for the debugToken config-fetch path.
+     */
+    #[DataProvider('debugTokenProvider')]
+    public function testExpFetchUrlCarriesExperienceIdLowCacheAndOptionalDebugToken(?string $debugToken): void
+    {
+        $apiManager = $this->buildApiManager($debugToken);
+        $this->queueExpConfigResponse();
+
+        $apiManager->getConfigForExperience(self::EXPERIENCE_ID);
+
+        $sentUri = (string) $this->mockHttpClient->getLastRequest()->getUri();
+
+        $this->assertStringContainsString('exp=' . self::EXPERIENCE_ID, $sentUri);
+        $this->assertStringContainsString('_conv_low_cache=1', $sentUri);
+
+        if ($debugToken !== null) {
+            $this->assertStringContainsString('debug_token=' . $debugToken, $sentUri);
+        } else {
+            $this->assertStringNotContainsString('debug_token=', $sentUri);
+        }
+    }
+
+    #[Test]
+    public function getConfigForExperienceReturnsParsedConfigResponseData(): void
+    {
+        $apiManager = $this->buildApiManager();
+        $this->queueExpConfigResponse();
+
+        $result = $apiManager->getConfigForExperience(self::EXPERIENCE_ID);
+
+        $this->assertInstanceOf(ConfigResponseData::class, $result);
+        $experiences = $result->getExperiences() ?? [];
+        $this->assertNotEmpty($experiences, 'exp= fetch response must be parsed into ConfigResponseData with the injected experience');
+        $this->assertSame(self::EXPERIENCE_ID, $experiences[0]['id'] ?? null);
+    }
+}

--- a/packages/Api/tests/ApiManagerPreviewFetchTest.php
+++ b/packages/Api/tests/ApiManagerPreviewFetchTest.php
@@ -77,15 +77,23 @@ class ApiManagerPreviewFetchTest extends TestCase
         );
     }
 
+    /**
+     * Response body shape verified against the backend OpenAPI contract
+     * (`backend/apiDoc/serving/src/responses/index.yaml` — `ProjectConfigResponse`
+     * resolves directly to the `ConfigResponseData` schema, with no enclosing
+     * envelope) and against the JS SDK's own real-HTTP-server integration test
+     * for `getConfigByExperience()`
+     * (`javascript-sdk/packages/api/tests/api-manager-config-by-experience.tests.ts`),
+     * whose mock server returns the config fields at the top level of the
+     * response body.
+     */
     private function queueExpConfigResponse(): void
     {
         $this->mockHttpClient->addResponse(new Response(200, ['Content-Type' => 'application/json'], (string) json_encode([
-            'data' => [
-                'account_id' => '999',
-                'project' => ['id' => '888'],
-                'experiences' => [
-                    ['id' => self::EXPERIENCE_ID, 'key' => 'preview-target', 'status' => 'draft', 'variations' => []],
-                ],
+            'account_id' => '999',
+            'project' => ['id' => '888'],
+            'experiences' => [
+                ['id' => self::EXPERIENCE_ID, 'key' => 'preview-target', 'status' => 'draft', 'variations' => []],
             ],
         ])));
     }

--- a/packages/Data/src/DataManager.php
+++ b/packages/Data/src/DataManager.php
@@ -281,6 +281,10 @@ final class DataManager implements DataManagerInterface
         $locationProperties = $attributes->locationProperties ?? null;
         $ignoreLocationProperties = $attributes->ignoreLocationProperties ?? false;
         $environment = $attributes->environment ?? $this->_environment;
+        // qs-02 capability (B) preview input — per-context suppression signal,
+        // forwarded to selectLocations() below so a preview context's "other
+        // experiences evaluate normally" location matching never persists.
+        $suppressPersistence = $attributes->suppressPersistence ?? false;
 
         // Log trace information
         $this->_loggerManager?->trace(
@@ -354,6 +358,7 @@ final class DataManager implements DataManagerInterface
                     $matchedLocations = $this->selectLocations($visitorId, $locations, new LocationAttributes([
                         'locationProperties' => $locationProperties,
                         'identityField' => $identityField,
+                        'suppressPersistence' => $suppressPersistence,
                     ]));
                     $matchedErrors = array_filter($matchedLocations, fn ($match) => $match instanceof RuleError);
                     if (count($matchedErrors) > 0) {
@@ -531,6 +536,8 @@ final class DataManager implements DataManagerInterface
         $enableTracking = $attributes->enableTracking ?? true;
         $ignoreLocationProperties = $attributes->ignoreLocationProperties ?? false;
         $environment = $attributes->environment ?? $this->_environment;
+        // qs-02 capability (B) preview input — per-context suppression signal.
+        $suppressPersistence = $attributes->suppressPersistence ?? false;
         // Log trace information
         $this->_loggerManager?->trace(
             'DataManager._getBucketingByField()',
@@ -557,6 +564,7 @@ final class DataManager implements DataManagerInterface
                 'locationProperties' => $locationProperties,
                 'ignoreLocationProperties' => $ignoreLocationProperties,
                 'environment' => $environment,
+                'suppressPersistence' => $suppressPersistence,
             ])
         );
         if ($experience) {
@@ -569,7 +577,8 @@ final class DataManager implements DataManagerInterface
                 $updateVisitorProperties,
                 new ConfigExperience($experience),
                 $forceVariationId,
-                $enableTracking
+                $enableTracking,
+                $suppressPersistence
             );
         }
 
@@ -665,6 +674,9 @@ final class DataManager implements DataManagerInterface
      * @param ConfigExperience $experience
      * @param ?string $forceVariationId
      * @param bool $enableTracking Defaults to true
+     * @param bool $suppressPersistence qs-02 capability (B) preview input — when true,
+     *     suppresses the stored-decision write AND the bucketing-event enqueue
+     *     regardless of $enableTracking. Defaults to false.
      * @return mixed BucketedVariation array or BucketingError or null
      * @private
      */
@@ -674,7 +686,8 @@ final class DataManager implements DataManagerInterface
         ?bool $updateVisitorProperties,
         ConfigExperience $experience,
         ?string $forceVariationId = null,
-        bool $enableTracking = true
+        bool $enableTracking = true,
+        bool $suppressPersistence = false
     ): array|BucketingError|null {
         // Initial validation
         if (empty($visitorId) || $experience === null || empty($experience->getId())) {
@@ -790,9 +803,12 @@ final class DataManager implements DataManagerInterface
             if ($updateVisitorProperties && !empty($visitorProperties)) {
                 $storeDataObj['segments'] = $visitorProperties;
             }
-            $this->putData($visitorId, $storeDataObj);
+            // qs-02: suppressed for a preview context — zero-trace, regardless of enableTracking.
+            if (!$suppressPersistence) {
+                $this->putData($visitorId, $storeDataObj);
+            }
             // Track bucketing event if enabled
-            if ($enableTracking) {
+            if ($enableTracking && !$suppressPersistence) {
                 $bucketingEvent = [
                     'experienceId' => (string)$experience->getId(),
                     'variationId' => (string)$variationId,
@@ -855,6 +871,66 @@ final class DataManager implements DataManagerInterface
             'id'
         );
         return $subItem !== null ? new ExperienceVariationConfig($subItem) : null;
+    }
+
+    /**
+     * Build a bucketed-variation array for a preview forced decision (qs-02
+     * capability B preview input), bypassing every normal gate — audiences,
+     * segments, locations, the environment check, experience status, variation
+     * status/traffic filters, stored decisions, and the bucketing hash. Pure:
+     * never calls putData() and never enqueues a tracking event, so it stays
+     * entirely per-context regardless of whether $experienceData came from the
+     * current shared config or from a one-off `?exp=` fetch — and never
+     * touches the shared entity list either way.
+     *
+     * @param array<string, mixed> $experienceData The experience data (from the current
+     *     config, or from a `?exp=` fetch response — same raw shape either way)
+     * @param string $variationId The variation id to force
+     * @return array<string, mixed>|null Same shape as a normal bucketed decision (see
+     *     _retrieveBucketing()), or null when $variationId does not exist on the given
+     *     experience — the caller (Context) treats this as inert bad input.
+     */
+    public function buildPreviewDecision(array $experienceData, string $variationId): ?array
+    {
+        $variationData = null;
+        foreach ($experienceData['variations'] ?? [] as $candidate) {
+            if (is_array($candidate) && (string)($candidate['id'] ?? '') === $variationId) {
+                $variationData = $candidate;
+                break;
+            }
+        }
+
+        if ($variationData === null) {
+            $this->_loggerManager?->warn(
+                'DataManager.buildPreviewDecision()',
+                Messages::PREVIEW_VARIATION_NOT_FOUND,
+                LogUtils::toLoggable(($this->_mapper)([
+                    'experienceId' => $experienceData['id'] ?? null,
+                    'variationId' => $variationId,
+                ]))
+            );
+            return null;
+        }
+
+        $experience = new ConfigExperience($experienceData);
+        $variation = new ExperienceVariationConfig($variationData);
+
+        return array_merge(
+            [
+                'experienceId' => $experience->getId(),
+                'experienceName' => $experience->getName(),
+                'experienceKey' => $experience->getKey(),
+            ],
+            ['bucketingAllocation' => null],
+            [
+                'id' => $variation->getId(),
+                'name' => $variation->getName(),
+                'key' => $variation->getKey(),
+                'traffic_allocation' => $variation->getTrafficAllocation(),
+                'status' => $variation->getStatus(),
+                'changes' => $variation->getChanges(),
+            ]
+        );
     }
 
     /**
@@ -985,6 +1061,8 @@ final class DataManager implements DataManagerInterface
         $locationProperties = $attributes->getLocationProperties();
         $identityField = $attributes->getIdentityField() ?? 'key';
         $forceEvent = $attributes->getForceEvent();
+        // qs-02 capability (B) preview input — per-context suppression signal.
+        $suppressPersistence = $attributes->getSuppressPersistence() ?? false;
 
         $this->_loggerManager?->trace(
             'DataManager.selectLocations()',
@@ -1071,8 +1149,10 @@ final class DataManager implements DataManagerInterface
             }
         }
 
-        // Store the data
-        $this->putData($visitorId, ['locations' => $locations]);
+        // Store the data (qs-02: suppressed for a preview context — zero-trace)
+        if (!$suppressPersistence) {
+            $this->putData($visitorId, ['locations' => $locations]);
+        }
 
         $this->_loggerManager?->debug(
             'DataManager.selectLocations()',
@@ -1120,6 +1200,9 @@ final class DataManager implements DataManagerInterface
      * @param array|null $goalData Optional array of associative arrays containing goal data
      * @param VisitorSegments|null $segments Optional visitor segments object
      * @param array|null $conversionSetting Optional associative array of conversion settings
+     * @param bool $suppressPersistence qs-02 capability (B) preview input — when true,
+     *     suppresses the goal-triggered write AND the conversion/transaction
+     *     enqueue. Defaults to false.
      * @return bool|RuleError Returns true on success, or a RuleError instance on failure
      */
     public function convert(
@@ -1128,7 +1211,8 @@ final class DataManager implements DataManagerInterface
         ?array $goalRule = null,
         ?array $goalData = null,
         ?VisitorSegments $segments = null,
-        ?array $conversionSetting = null
+        ?array $conversionSetting = null,
+        bool $suppressPersistence = false
     ): bool|RuleError {
         // Retrieve the goal based on goalId type
         $goal = is_string($goalId)
@@ -1187,15 +1271,17 @@ final class DataManager implements DataManagerInterface
             }
         }
 
-        // Store the goal as triggered
-        $this->putData($visitorId, ['goals' => [$goalId => true]]);
+        // Store the goal as triggered (qs-02: suppressed for a preview context — zero-trace)
+        if (!$suppressPersistence) {
+            $this->putData($visitorId, ['goals' => [$goalId => true]]);
+        }
 
         // Send conversion event if goal wasn't previously triggered
-        if (!$goalTriggered) {
+        if (!$goalTriggered && !$suppressPersistence) {
             $this->sendConversion($visitorId, $goal['id'], $bucketingData, $segments);
         }
         // Send transaction event if goalData exists and conditions are met
-        if ($goalData !== null && (!$goalTriggered || $forceMultipleTransactions)) {
+        if ($goalData !== null && (!$goalTriggered || $forceMultipleTransactions) && !$suppressPersistence) {
             $this->sendTransaction($visitorId, $goal['id'], $goalData, $bucketingData, $segments);
         }
 

--- a/packages/Data/src/Interfaces/DataManagerInterface.php
+++ b/packages/Data/src/Interfaces/DataManagerInterface.php
@@ -125,9 +125,22 @@ interface DataManagerInterface
      * @param GoalData[]|null $goalData Array of GoalData objects (optional)
      * @param VisitorSegments|null $segments (optional)
      * @param array|null $conversionSetting Associative array with ConversionSettingKey keys (optional)
+     * @param bool $suppressPersistence qs-02 capability (B) preview input — when true,
+     *     suppresses the goal-triggered write and the conversion/transaction enqueue
      * @return RuleError|bool
      */
-    public function convert(string $visitorId, string $goalId, ?array $goalRule = null, ?array $goalData = null, ?VisitorSegments $segments = null, ?array $conversionSetting = null): bool|RuleError;
+    public function convert(string $visitorId, string $goalId, ?array $goalRule = null, ?array $goalData = null, ?VisitorSegments $segments = null, ?array $conversionSetting = null, bool $suppressPersistence = false): bool|RuleError;
+
+    /**
+     * Build a bucketed-variation array for a preview forced decision (qs-02
+     * capability B preview input), bypassing every normal gate. Pure: never
+     * writes visitor state or enqueues a tracking event.
+     *
+     * @param array<string, mixed> $experienceData
+     * @param string $variationId
+     * @return array<string, mixed>|null
+     */
+    public function buildPreviewDecision(array $experienceData, string $variationId): ?array;
 
     /**
      * Get a list of entities by type.

--- a/packages/Enums/src/Messages.php
+++ b/packages/Enums/src/Messages.php
@@ -62,4 +62,8 @@ final class Messages
     public const NULL_RETURN_AUDIENCE_MISMATCH = 'Null return: visitor does not match audience rules';
     public const NULL_RETURN_LOCATION_MISMATCH = 'Null return: visitor does not match location rules';
     public const NULL_RETURN_EXPERIENCE_PAUSED = 'Null return: experience is paused/stopped';
+
+    // qs-02 capability (B) preview input
+    public const PREVIEW_EXPERIENCE_NOT_FOUND = 'Preview experience not found in config or via exp= fetch';
+    public const PREVIEW_VARIATION_NOT_FOUND = 'Preview variation not found on the resolved experience';
 }

--- a/packages/Php-sdk/src/Context.php
+++ b/packages/Php-sdk/src/Context.php
@@ -253,9 +253,6 @@ final class Context implements ContextInterface
         $forwardedData['visitorProperties'] = $visitorProperties;
         $forwardedData['environment'] = $forwardedData['environment'] ?? $this->environment;
         // qs-02: zero-trace across the WHOLE context once a preview is active.
-        // Note: this does NOT force the preview target's decision (that override
-        // is scoped to runExperience() per contract §2) — an experience absent
-        // from the shared config still won't appear in this bulk result.
         if ($this->previewExperience !== null) {
             $forwardedData['suppressPersistence'] = true;
         }
@@ -264,6 +261,31 @@ final class Context implements ContextInterface
             $this->visitorId,
             new BucketingAttributes($forwardedData)
         );
+
+        // qs-02 capability (B) contract §3 precedence — "preview forcing beats
+        // stored decisions and normal bucketing for the target experience" is
+        // method-agnostic, so the bulk method must honor it too, not just
+        // runExperience(). Scoped to the in-config preview target: when the
+        // target experience is present in config and would normally decide
+        // (running, environment-matching — i.e. it already appears in
+        // $bucketedVariations), replace that entry with the forced decision,
+        // mirroring runExperience()'s short-circuit at ~line 184. An experience
+        // absent from this bulk result (out-of-config-only via ?exp= fetch, or
+        // blocked by a status/environment/traffic gate the preview would
+        // otherwise bypass) is intentionally NOT injected here — replicating
+        // runExperience()'s full gate bypass for the bulk method would require
+        // restructuring how this method sources per-experience decisions, which
+        // is out of scope for this fix (see qs-02 decision-audit remediation,
+        // Defect 3 note in the PHP SDK decision log).
+        if ($this->previewExperience !== null) {
+            $previewKey = $this->previewExperience['key'] ?? null;
+            foreach ($bucketedVariations as $index => $variation) {
+                if (is_array($variation) && ($variation['experienceKey'] ?? null) === $previewKey) {
+                    $bucketedVariations[$index] = $this->previewDecision;
+                    break;
+                }
+            }
+        }
 
         $dtos = [];
         foreach ($bucketedVariations as $variation) {
@@ -305,18 +327,25 @@ final class Context implements ContextInterface
 
         $visitorProperties = $this->getVisitorProperties($attributes?->getVisitorProperties());
 
+        $forwardedData = [
+            'visitorProperties' => $visitorProperties,
+            'locationProperties' => $attributes?->getLocationProperties(),
+            'updateVisitorProperties' => $attributes?->getUpdateVisitorProperties(),
+            'typeCasting' => $attributes !== null && method_exists($attributes, 'getTypeCasting')
+                ? $attributes->getTypeCasting()
+                : true,
+            'environment' => $attributes?->getEnvironment() ?? $this->environment,
+        ];
+        // qs-02: zero-trace across the WHOLE context once a preview is active —
+        // runFeature() buckets every experience in config, not just a named one.
+        if ($this->previewExperience !== null) {
+            $forwardedData['suppressPersistence'] = true;
+        }
+
         $result = $this->featureManager->runFeature(
             $this->visitorId,
             $key,
-            new BucketingAttributes([
-                'visitorProperties' => $visitorProperties,
-                'locationProperties' => $attributes?->getLocationProperties(),
-                'updateVisitorProperties' => $attributes?->getUpdateVisitorProperties(),
-                'typeCasting' => $attributes !== null && method_exists($attributes, 'getTypeCasting')
-                    ? $attributes->getTypeCasting()
-                    : true,
-                'environment' => $attributes?->getEnvironment() ?? $this->environment,
-            ]),
+            new BucketingAttributes($forwardedData),
             $attributes?->getExperienceKeys()
         );
 
@@ -397,7 +426,7 @@ final class Context implements ContextInterface
 
         $visitorProperties = $this->getVisitorProperties($attributes?->getVisitorProperties());
 
-        $bucketedFeatures = $this->featureManager->runFeatures($this->visitorId, new BucketingAttributes([
+        $forwardedData = [
             'visitorProperties' => $visitorProperties,
             'locationProperties' => $attributes?->getLocationProperties(),
             'updateVisitorProperties' => $attributes?->getUpdateVisitorProperties(),
@@ -405,7 +434,14 @@ final class Context implements ContextInterface
                 ? $attributes->getTypeCasting()
                 : true,
             'environment' => $attributes?->getEnvironment() ?? $this->environment,
-        ]));
+        ];
+        // qs-02: zero-trace across the WHOLE context once a preview is active —
+        // runFeatures() buckets every experience in config.
+        if ($this->previewExperience !== null) {
+            $forwardedData['suppressPersistence'] = true;
+        }
+
+        $bucketedFeatures = $this->featureManager->runFeatures($this->visitorId, new BucketingAttributes($forwardedData));
 
         // Filter out RuleError results
         $matchedErrors = array_filter($bucketedFeatures, function ($match) {

--- a/packages/Php-sdk/src/Context.php
+++ b/packages/Php-sdk/src/Context.php
@@ -278,11 +278,22 @@ final class Context implements ContextInterface
         // is out of scope for this fix (see qs-02 decision-audit remediation,
         // Defect 3 note in the PHP SDK decision log).
         if ($this->previewExperience !== null) {
-            $previewKey = $this->previewExperience['key'] ?? null;
-            foreach ($bucketedVariations as $index => $variation) {
-                if (is_array($variation) && ($variation['experienceKey'] ?? null) === $previewKey) {
-                    $bucketedVariations[$index] = $this->previewDecision;
-                    break;
+            // Source the key from the decision actually built by
+            // DataManager::buildPreviewDecision() (experienceKey ===
+            // ConfigExperience::getKey()) rather than the raw config
+            // experience — this is the authoritative key used to build the
+            // forced decision. Guard against null/empty: without it, a
+            // bucketed variation with a missing/null `experienceKey` would
+            // spuriously match null === null and be overwritten with the
+            // preview decision (mirrors the defensive idiom in
+            // ApiManager::redactDebugTokenForLog()'s null/empty-token guard).
+            $previewKey = $this->previewDecision['experienceKey'] ?? null;
+            if ($previewKey !== null && $previewKey !== '') {
+                foreach ($bucketedVariations as $index => $variation) {
+                    if (is_array($variation) && ($variation['experienceKey'] ?? null) === $previewKey) {
+                        $bucketedVariations[$index] = $this->previewDecision;
+                        break;
+                    }
                 }
             }
         }

--- a/packages/Php-sdk/src/Context.php
+++ b/packages/Php-sdk/src/Context.php
@@ -30,9 +30,11 @@ use ConvertSdk\Interfaces\ExperienceManagerInterface;
 use ConvertSdk\Interfaces\FeatureManagerInterface;
 use ConvertSdk\Interfaces\LogManagerInterface;
 use ConvertSdk\Interfaces\SegmentsManagerInterface;
+use ConvertSdk\Preview\PreviewResolver;
 use ConvertSdk\Utils\ObjectUtils;
 use OpenAPI\Client\BucketingAttributes;
 use OpenAPI\Client\Config;
+use Psr\SimpleCache\CacheInterface;
 
 /**
  * Provides visitor context for running experiences, features, and tracking conversions.
@@ -46,6 +48,30 @@ final class Context implements ContextInterface
     private ?array $visitorProperties = null;
 
     /**
+     * qs-02 capability (B) preview input — the resolved experience data for the
+     * current preview target (set via {@see setPreview()}), or null when no
+     * preview is active or the target could not be resolved (bad input →
+     * inert, per contract §2). A non-null value here is the SOLE source of
+     * truth for "is this context in preview mode" — it gates BOTH the forced
+     * decision in {@see runExperience()} AND the zero-trace persistence
+     * suppression forwarded to every DataManager call this context makes.
+     *
+     * @var array<string, mixed>|null
+     */
+    private ?array $previewExperience = null;
+
+    /**
+     * qs-02 capability (B) preview input — the pre-built forced decision for
+     * {@see $previewExperience}, computed once in {@see setPreview()} via
+     * {@see DataManagerInterface::buildPreviewDecision()} so a bad variationId
+     * is caught eagerly (both experience and variation validity are decided
+     * once, at setPreview() time — never re-derived per runExperience() call).
+     *
+     * @var array<string, mixed>|null
+     */
+    private ?array $previewDecision = null;
+
+    /**
      * @param Config $config SDK configuration
      * @param string $visitorId Unique visitor identifier
      * @param EventManagerInterface $eventManager Event manager instance
@@ -56,6 +82,8 @@ final class Context implements ContextInterface
      * @param ApiManagerInterface $apiManager API manager instance
      * @param LogManagerInterface|null $loggerManager Optional logger manager instance
      * @param array<string, mixed>|null $visitorAttributes Initial visitor attributes for targeting
+     * @param CacheInterface|null $cache Optional PSR-16 cache, used for qs-02 preview-target
+     *     memoization (`preview_{experienceId}`, 60s TTL) — never the normal config cache
      *
      * @throws InvalidArgumentException If visitorId is empty
      */
@@ -70,6 +98,7 @@ final class Context implements ContextInterface
         private readonly ApiManagerInterface $apiManager,
         private readonly ?LogManagerInterface $loggerManager = null,
         ?array $visitorAttributes = null,
+        private readonly ?CacheInterface $cache = null,
     ) {
         if ($visitorId === '') {
             throw new InvalidArgumentException('Visitor ID must not be empty');
@@ -84,6 +113,53 @@ final class Context implements ContextInterface
             }
             $this->segmentsManager->putSegments($visitorId, $visitorAttributes);
         }
+    }
+
+    /**
+     * qs-02 capability (B) preview input — force this context to decide a
+     * specific variation for a specific experience, bypassing audiences,
+     * segments, locations, the environment check, experience status, variation
+     * status/traffic filters, stored decisions, and the bucketing hash.
+     *
+     * Resolution and variation validation both happen eagerly, here — not
+     * lazily inside runExperience() — so "the context behaves fully normally"
+     * on bad input (contract §2) is a single, context-wide decision rather
+     * than a per-call fallback. When resolution succeeds, this context
+     * becomes zero-trace for its ENTIRE lifetime (contract §2 "Zero-trace"):
+     * every runExperience()/runExperiences()/trackConversion() call this
+     * context makes afterwards suppresses visitor-state persistence and
+     * tracking enqueues, not just calls targeting $experienceId.
+     *
+     * Single preview target per context — calling this again overwrites the
+     * previous target (last-write-wins). Never leaks to other contexts: the
+     * resolved state lives entirely on this Context instance, never on the
+     * shared DataManager/ApiManager singletons.
+     *
+     * @param string $experienceId The experience id (numeric string)
+     * @param string $variationId The variation id to force (numeric string)
+     * @return void
+     */
+    public function setPreview(string $experienceId, string $variationId): void
+    {
+        $resolver = new PreviewResolver($this->dataManager, $this->apiManager, $this->cache, $this->loggerManager);
+        $experienceData = $resolver->resolveExperience($experienceId);
+
+        if ($experienceData === null) {
+            $this->previewExperience = null;
+            $this->previewDecision = null;
+            return;
+        }
+
+        $decision = $this->dataManager->buildPreviewDecision($experienceData, $variationId);
+        if ($decision === null) {
+            // Inert on bad input (contract §2) — DataManager already warned.
+            $this->previewExperience = null;
+            $this->previewDecision = null;
+            return;
+        }
+
+        $this->previewExperience = $experienceData;
+        $this->previewDecision = $decision;
     }
 
     /**
@@ -103,10 +179,32 @@ final class Context implements ContextInterface
             return null;
         }
 
+        // qs-02 capability (B) preview input — force the resolved decision when
+        // this experience key is the active preview target on this context.
+        if ($this->previewExperience !== null && ($this->previewExperience['key'] ?? null) === $experienceKey) {
+            $this->eventManager->fire(
+                SystemEvents::Bucketing,
+                [
+                    'visitorId' => $this->visitorId,
+                    'experienceKey' => $experienceKey,
+                    'variationKey' => $this->previewDecision['key'] ?? null,
+                ],
+                null,
+                true
+            );
+
+            return $this->mapToBucketedVariationDto($this->previewDecision);
+        }
+
         $visitorProperties = $this->getVisitorProperties($attributes?->getVisitorProperties());
         $forwardedData = $attributes ? get_object_vars($attributes) : [];
         $forwardedData['visitorProperties'] = $visitorProperties;
         $forwardedData['environment'] = $forwardedData['environment'] ?? $this->environment;
+        // qs-02: zero-trace across the WHOLE context once a preview is active —
+        // other experiences still decide normally, but never persist/track.
+        if ($this->previewExperience !== null) {
+            $forwardedData['suppressPersistence'] = true;
+        }
         $result = $this->experienceManager->selectVariation(
             $this->visitorId,
             $experienceKey,
@@ -154,6 +252,13 @@ final class Context implements ContextInterface
         $forwardedData = $attributes ? get_object_vars($attributes) : [];
         $forwardedData['visitorProperties'] = $visitorProperties;
         $forwardedData['environment'] = $forwardedData['environment'] ?? $this->environment;
+        // qs-02: zero-trace across the WHOLE context once a preview is active.
+        // Note: this does NOT force the preview target's decision (that override
+        // is scoped to runExperience() per contract §2) — an experience absent
+        // from the shared config still won't appear in this bulk result.
+        if ($this->previewExperience !== null) {
+            $forwardedData['suppressPersistence'] = true;
+        }
 
         $bucketedVariations = $this->experienceManager->selectVariations(
             $this->visitorId,
@@ -374,7 +479,9 @@ final class Context implements ContextInterface
             $attributes?->ruleData,
             $conversionData,
             $segments,
-            $attributes?->conversionSetting
+            $attributes?->conversionSetting,
+            // qs-02: zero-trace across the WHOLE context once a preview is active.
+            $this->previewExperience !== null
         );
 
         if ($triggered instanceof RuleError) {

--- a/packages/Php-sdk/src/Core.php
+++ b/packages/Php-sdk/src/Core.php
@@ -242,27 +242,34 @@ final class Core implements CoreInterface
             ? $this->config->getApi()['endpoint']['config']
             : '';
 
-        // Check cache first
-        $cachedData = $this->cache->get($cacheKey);
+        // qs-02 AC2 — with debugToken set, the PSR-16 config cache entry is
+        // neither read nor written: every request fetches live from origin.
+        $debugToken = $this->config->getDebugToken();
+        $skipCache = $debugToken !== null && $debugToken !== '';
 
-        if ($cachedData instanceof ConfigResponseData) {
-            $this->loggerManager?->trace('Core.fetchConfig()', 'Using cached config');
+        $cachedData = null;
+        if (!$skipCache) {
+            $cachedData = $this->cache->get($cacheKey);
 
-            try {
-                $this->configValidator->validate($cachedData);
-            } catch (ConfigValidationException $e) {
-                $this->loggerManager?->error('Core.fetchConfig()', ['error' => 'Cached config invalid, fetching fresh: ' . $e->getMessage()]);
-                $this->cache->delete($cacheKey);
+            if ($cachedData instanceof ConfigResponseData) {
+                $this->loggerManager?->trace('Core.fetchConfig()', 'Using cached config');
+
+                try {
+                    $this->configValidator->validate($cachedData);
+                } catch (ConfigValidationException $e) {
+                    $this->loggerManager?->error('Core.fetchConfig()', ['error' => 'Cached config invalid, fetching fresh: ' . $e->getMessage()]);
+                    $this->cache->delete($cacheKey);
+                    $cachedData = null;
+                }
+            } else {
                 $cachedData = null;
             }
-        } else {
-            $cachedData = null;
         }
 
         if ($cachedData !== null) {
             $data = $cachedData;
         } else {
-            // Cache miss — fetch via HTTP
+            // Cache miss (or cache skipped for debugToken) — fetch via HTTP
             try {
                 $data = $this->apiManager->getConfig();
             } catch (\RuntimeException $error) {
@@ -278,9 +285,11 @@ final class Core implements CoreInterface
             // Validate fresh config
             $this->configValidator->validate($data);
 
-            // Store in cache
-            $this->cache->set($cacheKey, $data, $this->dataRefreshInterval);
-            $this->loggerManager?->trace('Core.fetchConfig()', 'Config cached with TTL ' . $this->dataRefreshInterval . 's');
+            if (!$skipCache) {
+                // Store in cache
+                $this->cache->set($cacheKey, $data, $this->dataRefreshInterval);
+                $this->loggerManager?->trace('Core.fetchConfig()', 'Config cached with TTL ' . $this->dataRefreshInterval . 's');
+            }
         }
 
         $this->dataManager->setConfigData($data);

--- a/packages/Php-sdk/src/Core.php
+++ b/packages/Php-sdk/src/Core.php
@@ -171,7 +171,8 @@ final class Core implements CoreInterface
             $this->segmentsManager,
             $this->apiManager,
             $this->loggerManager,
-            $visitorAttributes
+            $visitorAttributes,
+            $this->cache
         );
     }
 

--- a/packages/Php-sdk/src/Interfaces/ContextInterface.php
+++ b/packages/Php-sdk/src/Interfaces/ContextInterface.php
@@ -164,4 +164,20 @@ interface ContextInterface
      * @return string The visitor ID
      */
     public function getVisitorId(): string;
+
+    /**
+     * qs-02 capability (B) preview input — force this context to decide a
+     * specific variation for a specific experience, bypassing every normal
+     * gate (audiences, segments, locations, environment, statuses, traffic,
+     * stored decisions, bucketing hash). Once resolved, this context becomes
+     * zero-trace for its entire lifetime: no tracking events and no
+     * visitor-state persistence writes, for any experience run through it.
+     * Inert on bad input (unknown experience/variation id) — the context then
+     * behaves fully normally. Per-context only; never leaks to other contexts.
+     *
+     * @param string $experienceId The experience id (numeric string)
+     * @param string $variationId The variation id to force (numeric string)
+     * @return void
+     */
+    public function setPreview(string $experienceId, string $variationId): void;
 }

--- a/packages/Php-sdk/src/Preview/PreviewParam.php
+++ b/packages/Php-sdk/src/Preview/PreviewParam.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Convert PHP SDK
+ * Version 1.0.0
+ * Copyright (c) 2020 Convert Insights, Inc
+ * License Apache-2.0
+ */
+
+namespace ConvertSdk\Preview;
+
+/**
+ * qs-02 capability (B) preview input — pure static parser for the canonical
+ * `convert_preview={experienceId}.{variationId}` link param (contract §2),
+ * mirroring the web force-param format `_conv_eforce={expId}.{varId}`.
+ *
+ * The application is responsible for extracting the raw query-string value
+ * from the request URL and handing it to {@see parse()}; the SDK never reads
+ * request superglobals or query strings directly.
+ */
+final class PreviewParam
+{
+    /**
+     * Parse a `convert_preview` link-param value into its experience/variation
+     * id pair. Both ids must be non-negative integer strings, dot-separated,
+     * with no surrounding whitespace or trailing garbage.
+     *
+     * @param string $value The raw `convert_preview` query-string value
+     * @return array{experienceId: string, variationId: string}|null The parsed
+     *     pair, or null when the value is malformed.
+     */
+    public static function parse(string $value): ?array
+    {
+        if (preg_match('/^(\d+)\.(\d+)$/', $value, $matches) !== 1) {
+            return null;
+        }
+
+        return [
+            'experienceId' => $matches[1],
+            'variationId' => $matches[2],
+        ];
+    }
+}

--- a/packages/Php-sdk/src/Preview/PreviewResolver.php
+++ b/packages/Php-sdk/src/Preview/PreviewResolver.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Convert PHP SDK
+ * Version 1.0.0
+ * Copyright (c) 2020 Convert Insights, Inc
+ * License Apache-2.0
+ */
+
+namespace ConvertSdk\Preview;
+
+use ConvertSdk\Enums\Messages;
+use ConvertSdk\Interfaces\ApiManagerInterface;
+use ConvertSdk\Interfaces\DataManagerInterface;
+use ConvertSdk\Interfaces\LogManagerInterface;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * qs-02 capability (B) preview input — resolves the experience data for a
+ * preview target (contract §2 "Resolution"):
+ *
+ * 1. If the experience is already present in the current config, use it directly
+ *    — no fetch needed.
+ * 2. Otherwise, memoize per-experienceId for 60s under a preview-scoped cache
+ *    key (`preview_{experienceId}` — NEVER the normal config cache key) and,
+ *    on a cache miss, fetch via `ApiManagerInterface::getConfigForExperience()`
+ *    (which forces `exp={id}` + `_conv_low_cache=1`, plus `debug_token` when
+ *    configured).
+ *
+ * Never mutates the shared DataManager entity list — the resolved experience
+ * data is handed back to the caller (Context) for per-context use only, so a
+ * preview target absent from the shared config never leaks into other
+ * contexts sharing the same DataManager/ApiManager singletons.
+ */
+final class PreviewResolver
+{
+    private const CACHE_TTL_SECONDS = 60;
+    private const CACHE_KEY_PREFIX = 'preview_';
+
+    public function __construct(
+        private readonly DataManagerInterface $dataManager,
+        private readonly ApiManagerInterface $apiManager,
+        private readonly ?CacheInterface $cache,
+        private readonly ?LogManagerInterface $loggerManager = null,
+    ) {
+    }
+
+    /**
+     * Resolve the raw experience data array for the given experience id.
+     *
+     * @param string $experienceId
+     * @return array<string, mixed>|null The experience data, or null when it
+     *     cannot be resolved from the current config nor via the `?exp=` fetch.
+     */
+    public function resolveExperience(string $experienceId): ?array
+    {
+        $existing = $this->dataManager->getEntityById($experienceId, 'experiences');
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        $cacheKey = self::CACHE_KEY_PREFIX . $experienceId;
+        if ($this->cache !== null) {
+            $cached = $this->cache->get($cacheKey);
+            if (is_array($cached)) {
+                return $cached;
+            }
+        }
+
+        try {
+            $response = $this->apiManager->getConfigForExperience($experienceId);
+        } catch (\Throwable $e) {
+            $this->loggerManager?->warn(
+                'PreviewResolver.resolveExperience()',
+                Messages::PREVIEW_EXPERIENCE_NOT_FOUND,
+                ['experienceId' => $experienceId, 'error' => $e->getMessage()]
+            );
+            return null;
+        }
+
+        foreach ($response->getExperiences() ?? [] as $candidate) {
+            if (is_array($candidate) && (string)($candidate['id'] ?? '') === $experienceId) {
+                $this->cache?->set($cacheKey, $candidate, self::CACHE_TTL_SECONDS);
+                return $candidate;
+            }
+        }
+
+        $this->loggerManager?->warn(
+            'PreviewResolver.resolveExperience()',
+            Messages::PREVIEW_EXPERIENCE_NOT_FOUND,
+            ['experienceId' => $experienceId]
+        );
+
+        return null;
+    }
+}

--- a/packages/Php-sdk/tests/Config/CoreDebugTokenCacheTest.php
+++ b/packages/Php-sdk/tests/Config/CoreDebugTokenCacheTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConvertSdk\Tests\Config;
+
+use ConvertSdk\Core;
+use ConvertSdk\Event\Interfaces\EventManagerInterface;
+use ConvertSdk\Interfaces\ApiManagerInterface;
+use ConvertSdk\Interfaces\DataManagerInterface;
+use ConvertSdk\Interfaces\ExperienceManagerInterface;
+use ConvertSdk\Interfaces\FeatureManagerInterface;
+use ConvertSdk\Interfaces\LogManagerInterface;
+use ConvertSdk\Interfaces\SegmentsManagerInterface;
+use OpenAPI\Client\Config;
+use OpenAPI\Client\Model\ConfigResponseData;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * qs-02 capability (A) `debugToken` — AC2 cache elimination.
+ *
+ * With `debugToken` set, `Core::fetchConfig()` must neither read nor write
+ * the PSR-16 config cache entry: every request (i.e. every `Core` instance,
+ * since PHP-FPM is stateless between requests) hits the (mocked) origin via
+ * `ApiManagerInterface::getConfig()`.
+ *
+ * @see ../../../../../ai-driven-product-dev/_bmad-output/planning-artifacts/2026-03-13-convert-php-sdk/qs-02-experiment-preview.md
+ */
+class CoreDebugTokenCacheTest extends TestCase
+{
+    private const DEBUG_TOKEN = 'qa-debug-token-xyz789';
+
+    private function validConfigData(): ConfigResponseData
+    {
+        return new ConfigResponseData([
+            'account_id' => '10022898',
+            'project' => ['id' => '10025986', 'name' => 'Test Project'],
+        ]);
+    }
+
+    private function makeConfig(string $sdkKey, string $debugToken = self::DEBUG_TOKEN): Config
+    {
+        return new Config([
+            'sdkKey' => $sdkKey,
+            'debugToken' => $debugToken,
+            'environment' => 'staging',
+            'api' => [
+                'endpoint' => [
+                    'config' => 'http://cdn.example.com',
+                    'track' => 'http://track.example.com',
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @return array{
+     *     dataManager: DataManagerInterface&\PHPUnit\Framework\MockObject\MockObject,
+     *     eventManager: EventManagerInterface&\PHPUnit\Framework\MockObject\MockObject,
+     *     experienceManager: ExperienceManagerInterface&\PHPUnit\Framework\MockObject\MockObject,
+     *     featureManager: FeatureManagerInterface&\PHPUnit\Framework\MockObject\MockObject,
+     *     segmentsManager: SegmentsManagerInterface&\PHPUnit\Framework\MockObject\MockObject,
+     *     loggerManager: LogManagerInterface&\PHPUnit\Framework\MockObject\MockObject,
+     * }
+     */
+    private function makeDependencies(): array
+    {
+        return [
+            'dataManager' => $this->createMock(DataManagerInterface::class),
+            'eventManager' => $this->createMock(EventManagerInterface::class),
+            'experienceManager' => $this->createMock(ExperienceManagerInterface::class),
+            'featureManager' => $this->createMock(FeatureManagerInterface::class),
+            'segmentsManager' => $this->createMock(SegmentsManagerInterface::class),
+            'loggerManager' => $this->createMock(LogManagerInterface::class),
+        ];
+    }
+
+    /**
+     * @param array{
+     *     dataManager: DataManagerInterface,
+     *     eventManager: EventManagerInterface,
+     *     experienceManager: ExperienceManagerInterface,
+     *     featureManager: FeatureManagerInterface,
+     *     segmentsManager: SegmentsManagerInterface,
+     *     loggerManager: LogManagerInterface,
+     * } $deps
+     */
+    private function buildCore(Config $config, ApiManagerInterface $apiManager, CacheInterface $cache, array $deps): Core
+    {
+        return new Core(
+            $config,
+            $deps['dataManager'],
+            $deps['eventManager'],
+            $deps['experienceManager'],
+            $deps['featureManager'],
+            $deps['segmentsManager'],
+            $apiManager,
+            $cache,
+            Core::DEFAULT_DATA_REFRESH_INTERVAL,
+            $deps['loggerManager'],
+        );
+    }
+
+    /**
+     * A non-throwing counting spy around the PSR-16 cache contract.
+     *
+     * A PHPUnit mock configured with `expects($this->never())` would work
+     * too, but `Core::initialize()` wraps `fetchConfig()` in a broad
+     * `catch (\Exception $e)` — the mock's ExpectationFailedException would
+     * be swallowed there and surface only as an indirect, confusing failure
+     * downstream (e.g. "getConfig() expected once, called 0 times"). A
+     * counting spy that never throws sidesteps that interaction and gives a
+     * direct, unambiguous assertion on call counts after construction.
+     */
+    private function makeCountingCache(): CacheInterface
+    {
+        return new class () implements CacheInterface {
+            public int $getCalls = 0;
+            public int $setCalls = 0;
+            public int $deleteCalls = 0;
+
+            public function get(string $key, mixed $default = null): mixed
+            {
+                $this->getCalls++;
+                return $default;
+            }
+
+            public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null): bool
+            {
+                $this->setCalls++;
+                return true;
+            }
+
+            public function delete(string $key): bool
+            {
+                $this->deleteCalls++;
+                return true;
+            }
+
+            public function clear(): bool
+            {
+                return true;
+            }
+
+            public function has(string $key): bool
+            {
+                return false;
+            }
+
+            public function getMultiple(iterable $keys, mixed $default = null): iterable
+            {
+                return [];
+            }
+
+            public function setMultiple(iterable $values, null|int|\DateInterval $ttl = null): bool
+            {
+                return true;
+            }
+
+            public function deleteMultiple(iterable $keys): bool
+            {
+                return true;
+            }
+        };
+    }
+
+    /**
+     * @param CacheInterface&object{getCalls: int, setCalls: int, deleteCalls: int} $cache
+     */
+    private function assertCacheNeverConsulted(CacheInterface $cache): void
+    {
+        $this->assertSame(0, $cache->getCalls, 'PSR-16 cache->get() must not be consulted when debugToken is set');
+        $this->assertSame(0, $cache->setCalls, 'PSR-16 cache->set() must not be written to when debugToken is set');
+        $this->assertSame(0, $cache->deleteCalls, 'PSR-16 cache->delete() must not be invoked when debugToken is set');
+    }
+
+    /**
+     * AC2 — a single fetch with debugToken set must not touch the PSR-16
+     * config cache entry at all (no get/set/delete), and must hit origin.
+     */
+    #[Test]
+    public function debugTokenSkipsCacheReadAndWriteOnFetch(): void
+    {
+        $configData = $this->validConfigData();
+
+        $apiManager = $this->createMock(ApiManagerInterface::class);
+        $apiManager->expects($this->once())->method('getConfig')->willReturn($configData);
+
+        $cache = $this->makeCountingCache();
+
+        $deps = $this->makeDependencies();
+        $deps['dataManager']->expects($this->once())->method('setConfigData')->with($configData);
+
+        $config = $this->makeConfig('debug_key_1');
+
+        $core = $this->buildCore($config, $apiManager, $cache, $deps);
+        $this->assertInstanceOf(Core::class, $core);
+        $this->assertCacheNeverConsulted($cache);
+    }
+
+    /**
+     * AC2 — two sequential fetches (modelled as two separate `Core`
+     * instances, since PHP-FPM tears down state between requests) must both
+     * hit origin; the shared PSR-16 cache backend must never be consulted.
+     */
+    #[Test]
+    public function debugTokenCausesEveryRequestToHitOriginAcrossSeparateCoreInstances(): void
+    {
+        $configData = $this->validConfigData();
+
+        $apiManager = $this->createMock(ApiManagerInterface::class);
+        $apiManager->expects($this->exactly(2))->method('getConfig')->willReturn($configData);
+
+        $cache = $this->makeCountingCache();
+
+        $config = $this->makeConfig('debug_key_2');
+
+        $firstCore = $this->buildCore($config, $apiManager, $cache, $this->makeDependencies());
+        $secondCore = $this->buildCore($config, $apiManager, $cache, $this->makeDependencies());
+
+        $this->assertInstanceOf(Core::class, $firstCore);
+        $this->assertInstanceOf(Core::class, $secondCore);
+        $this->assertCacheNeverConsulted($cache);
+    }
+}

--- a/packages/Php-sdk/tests/Preview/ContextPreviewTest.php
+++ b/packages/Php-sdk/tests/Preview/ContextPreviewTest.php
@@ -309,16 +309,23 @@ class ContextPreviewTest extends TestCase
     }
 
     /**
+     * Response body shape verified against the backend OpenAPI contract
+     * (`backend/apiDoc/serving/src/responses/index.yaml` — `ProjectConfigResponse`
+     * resolves directly to the `ConfigResponseData` schema, with no enclosing
+     * envelope) and against the JS SDK's own real-HTTP-server integration test
+     * for `getConfigByExperience()`
+     * (`javascript-sdk/packages/api/tests/api-manager-config-by-experience.tests.ts`),
+     * whose mock server returns the config fields at the top level of the
+     * response body.
+     *
      * @param array<string, mixed> $experience
      */
     private function queueExpFetchResponse(array $experience): void
     {
         $this->mockHttpClient->addResponse(new Response(200, ['Content-Type' => 'application/json'], (string) json_encode([
-            'data' => [
-                'account_id' => 'acct-1',
-                'project' => ['id' => 'proj-1'],
-                'experiences' => [$experience],
-            ],
+            'account_id' => 'acct-1',
+            'project' => ['id' => 'proj-1'],
+            'experiences' => [$experience],
         ])));
     }
 

--- a/packages/Php-sdk/tests/Preview/ContextPreviewTest.php
+++ b/packages/Php-sdk/tests/Preview/ContextPreviewTest.php
@@ -1,0 +1,563 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConvertSdk\Tests\Preview;
+
+use ConvertSdk\ApiManager;
+use ConvertSdk\BucketingManager;
+use ConvertSdk\Core;
+use ConvertSdk\DataManager;
+use ConvertSdk\DTO\BucketedVariation;
+use ConvertSdk\Event\EventManager;
+use ConvertSdk\ExperienceManager;
+use ConvertSdk\Interfaces\FeatureManagerInterface;
+use ConvertSdk\Interfaces\SegmentsManagerInterface;
+use ConvertSdk\LogManager;
+use ConvertSdk\RuleManager;
+use Http\Mock\Client as MockHttpClient;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\Response;
+use OpenAPI\Client\BucketingAttributes;
+use OpenAPI\Client\Config;
+use OpenAPI\Client\Model\ConfigResponseData;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * Counting/recording spy for the PSR-16 cache Core receives — used to prove
+ * qs-02 AC8's memoization key scheme (`preview_{experienceId}`, never the
+ * normal `convert_sdk.config.*` key) without asserting on an implementation
+ * detail beyond "which keys were touched".
+ */
+class RecordingCache implements CacheInterface
+{
+    /** @var array<int, array{op: string, key: string}> */
+    public array $calls = [];
+
+    /** @var array<string, mixed> */
+    private array $store = [];
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        $this->calls[] = ['op' => 'get', 'key' => $key];
+        return $this->store[$key] ?? $default;
+    }
+
+    public function set(string $key, mixed $value, \DateInterval|int|null $ttl = null): bool
+    {
+        $this->calls[] = ['op' => 'set', 'key' => $key];
+        $this->store[$key] = $value;
+        return true;
+    }
+
+    public function delete(string $key): bool
+    {
+        $this->calls[] = ['op' => 'delete', 'key' => $key];
+        unset($this->store[$key]);
+        return true;
+    }
+
+    public function clear(): bool
+    {
+        $this->store = [];
+        return true;
+    }
+
+    public function has(string $key): bool
+    {
+        return array_key_exists($key, $this->store);
+    }
+
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    {
+        $result = [];
+        foreach ($keys as $key) {
+            $result[$key] = $this->get($key, $default);
+        }
+        return $result;
+    }
+
+    public function setMultiple(iterable $values, \DateInterval|int|null $ttl = null): bool
+    {
+        foreach ($values as $key => $value) {
+            $this->set($key, $value, $ttl);
+        }
+        return true;
+    }
+
+    public function deleteMultiple(iterable $keys): bool
+    {
+        foreach ($keys as $key) {
+            $this->delete($key);
+        }
+        return true;
+    }
+}
+
+/**
+ * Counting spy for the duck-typed visitor dataStore (get/set, per
+ * DataManager::setDataStore()) — used to prove qs-02 AC6's "zero visitor-state
+ * persistence writes" and AC7's "concurrent non-preview context persists
+ * normally" without depending on cache internals.
+ */
+class RecordingDataStore
+{
+    public int $setCalls = 0;
+
+    /** @var array<int, string> */
+    public array $setKeys = [];
+
+    /** @var array<string, mixed> */
+    private array $data = [];
+
+    public function get(?string $key = null): mixed
+    {
+        return $key === null ? $this->data : ($this->data[$key] ?? null);
+    }
+
+    public function set(string $key, mixed $value): void
+    {
+        $this->setCalls++;
+        $this->setKeys[] = $key;
+        $this->data[$key] = $value;
+    }
+}
+
+/**
+ * qs-02 capability (B) preview input — AC4, AC5, AC6, AC7, AC8 (Context/Core
+ * integration level).
+ *
+ * Every rig below wires REAL BucketingManager/RuleManager/DataManager/
+ * ExperienceManager/ApiManager instances (mirrors ContextTest.php's
+ * construction pattern) so the bypass assertions (AC5) exercise the actual
+ * gating code — matchRulesByField's environment check, isVariationActive's
+ * status/traffic filter, and the stored-decision-first branch in
+ * DataManager::_retrieveBucketing() — rather than a mock that trivially
+ * returns whatever the test wants. FeatureManager/SegmentsManager are mocked
+ * since no test here exercises features or segments.
+ *
+ * Only ApiManager's PSR-18 HTTP client (Http\Mock\Client) and the PSR-16
+ * cache / visitor dataStore (RecordingCache / RecordingDataStore, above) are
+ * test doubles — both are spies, not stubs, so every assertion is on real
+ * call counts/keys/URLs the SDK actually produced.
+ *
+ * "Shutdown" (AC6) is modeled by directly invoking
+ * `ApiManager::releaseQueue('shutdown')` — the exact call
+ * `ConvertSDK::create()`'s `register_shutdown_function` handler makes — since
+ * PHPUnit cannot observe a real PHP-FPM process teardown.
+ *
+ * RED-phase note (qs-02 PHP-2, TDD RED): `Context::setPreview()` does not
+ * exist yet. Every test below is expected to fail with
+ * `Error: Call to undefined method ConvertSdk\Context::setPreview()` until
+ * the PHP-2 GREEN implementation lands.
+ *
+ * @see ../../../../../ai-driven-product-dev/_bmad-output/planning-artifacts/2026-03-13-convert-php-sdk/qs-02-experiment-preview.md
+ */
+class ContextPreviewTest extends TestCase
+{
+    private const ENVIRONMENT = 'production';
+    private const HOST = 'http://localhost';
+    private const PORT = 8093;
+    private const OTHER_EXPERIENCE_ID = '500';
+    private const OTHER_EXPERIENCE_KEY = 'other-exp';
+    private const GOAL_KEY = 'preview-goal';
+    private const NO_LOCATION_GATE = ['ignoreLocationProperties' => true];
+
+    private MockHttpClient $mockHttpClient;
+    private Psr17Factory $psr17Factory;
+
+    protected function setUp(): void
+    {
+        $this->mockHttpClient = new MockHttpClient();
+        $this->psr17Factory = new Psr17Factory();
+    }
+
+    // -- Rig construction ----------------------------------------------------------------
+
+    /**
+     * Builds a fresh Core wired with real managers sharing ONE ApiManager/DataManager
+     * pair (mirrors ConvertSDK::create()'s single-singleton wiring, per the "shared
+     * singleton managers" crux documented for this task). `$extraExperiences` are
+     * visible in the config from the moment the rig is built — i.e. "already in the
+     * current config" per qs-02 contract §2, needing no ?exp= fetch.
+     *
+     * @param array<int, array<string, mixed>> $extraExperiences
+     * @return array{core: Core, dataManager: DataManager, apiManager: ApiManager, cache: RecordingCache, dataStore: RecordingDataStore}
+     */
+    private function buildRig(array $extraExperiences = []): array
+    {
+        $data = new ConfigResponseData([
+            'account_id' => 'acct-1',
+            'project' => ['id' => 'proj-1'],
+            'experiences' => array_merge([$this->otherExperience()], $extraExperiences),
+            'goals' => [
+                ['id' => '7001', 'key' => self::GOAL_KEY, 'name' => 'Preview Goal', 'rules' => null],
+            ],
+        ]);
+
+        $config = new Config([
+            'environment' => self::ENVIRONMENT,
+            'data' => $data,
+            'api' => [
+                'endpoint' => [
+                    'config' => self::HOST . ':' . self::PORT,
+                    'track' => self::HOST . ':' . self::PORT,
+                ],
+            ],
+            'network' => ['tracking' => false],
+        ]);
+
+        $eventManager = new EventManager();
+        $apiManager = new ApiManager(
+            $config,
+            $eventManager,
+            null,
+            $this->mockHttpClient,
+            $this->psr17Factory,
+            $this->psr17Factory
+        );
+        $dataManager = new DataManager(
+            $config,
+            new BucketingManager(),
+            new RuleManager(),
+            $eventManager,
+            $apiManager,
+            new LogManager()
+        );
+        $dataStore = new RecordingDataStore();
+        $dataManager->setDataStore($dataStore);
+
+        $experienceManager = new ExperienceManager(dataManager: $dataManager);
+        $cache = new RecordingCache();
+
+        $core = new Core(
+            $config,
+            $dataManager,
+            $eventManager,
+            $experienceManager,
+            $this->createMock(FeatureManagerInterface::class),
+            $this->createMock(SegmentsManagerInterface::class),
+            $apiManager,
+            $cache,
+            Core::DEFAULT_DATA_REFRESH_INTERVAL,
+            null,
+        );
+
+        return [
+            'core' => $core,
+            'dataManager' => $dataManager,
+            'apiManager' => $apiManager,
+            'cache' => $cache,
+            'dataStore' => $dataStore,
+        ];
+    }
+
+    /**
+     * A location/audience-agnostic, always-decidable experience present in the base
+     * config of every rig — used to prove "other experiences still evaluate and
+     * decide normally on a preview context" (AC6) and "a concurrent non-preview
+     * context buckets normally" (AC7).
+     *
+     * @return array<string, mixed>
+     */
+    private function otherExperience(): array
+    {
+        return [
+            'id' => self::OTHER_EXPERIENCE_ID,
+            'key' => self::OTHER_EXPERIENCE_KEY,
+            'name' => 'Other Experience',
+            'status' => 'running',
+            'variations' => [
+                $this->variation(self::OTHER_EXPERIENCE_ID . '-A', 'a'),
+                $this->variation(self::OTHER_EXPERIENCE_ID . '-B', 'b'),
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $experienceOverrides
+     * @param array<int, array<string, mixed>> $variations
+     * @return array<string, mixed>
+     */
+    private function experienceFixture(string $id, string $key, array $experienceOverrides, array $variations): array
+    {
+        return array_merge([
+            'id' => $id,
+            'key' => $key,
+            'name' => 'Preview Target ' . $key,
+            'status' => 'running',
+            'variations' => $variations,
+        ], $experienceOverrides);
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     * @return array<string, mixed>
+     */
+    private function variation(string $id, string $key, array $overrides = []): array
+    {
+        return array_merge([
+            'id' => $id,
+            'key' => $key,
+            'status' => 'running',
+            'traffic_allocation' => 50,
+            'changes' => [['id' => 'chg-' . $id, 'type' => 'fullStackFeature', 'data' => []]],
+        ], $overrides);
+    }
+
+    /**
+     * @param array<string, mixed> $experience
+     */
+    private function queueExpFetchResponse(array $experience): void
+    {
+        $this->mockHttpClient->addResponse(new Response(200, ['Content-Type' => 'application/json'], (string) json_encode([
+            'data' => [
+                'account_id' => 'acct-1',
+                'project' => ['id' => 'proj-1'],
+                'experiences' => [$experience],
+            ],
+        ])));
+    }
+
+    /**
+     * @return array<int, \Psr\Http\Message\RequestInterface>
+     */
+    private function trackRequests(): array
+    {
+        return array_values(array_filter(
+            $this->mockHttpClient->getRequests(),
+            fn ($request) => str_contains((string) $request->getUri(), '/track/')
+        ));
+    }
+
+    /**
+     * @return array<int, \Psr\Http\Message\RequestInterface>
+     */
+    private function expRequestsFor(string $experienceId): array
+    {
+        return array_values(array_filter(
+            $this->mockHttpClient->getRequests(),
+            fn ($request) => str_contains((string) $request->getUri(), 'exp=' . $experienceId)
+        ));
+    }
+
+    // -- AC4 + AC5: full bypass sweep -----------------------------------------------------
+
+    /**
+     * Six cases, each disabling exactly one normal gate that would otherwise block or
+     * redirect the decision; the shared assertion is "preview forces the given
+     * variation regardless, and — where a real non-preview control call is
+     * meaningful — the non-preview path is unaffected by the preview override."
+     *
+     * 'draft status' is also AC4's literal scenario ("a draft experience delivered
+     * only via the ?exp= fetch").
+     *
+     * @return array<string, array{
+     *     0: string, 1: string, 2: array<string, mixed>,
+     *     3: array<int, array<string, mixed>>, 4: bool, 5: ?string, 6: string, 7: ?string
+     * }>
+     */
+    public static function bypassCasesProvider(): array
+    {
+        return [
+            'draft status — delivered only via ?exp= fetch (AC4)' => [
+                '9001', 'draft-exp', ['status' => 'draft'],
+                [['id' => '9001-A', 'key' => 'a'], ['id' => '9001-B', 'key' => 'b']],
+                false, null, '9001-B', null,
+            ],
+            'paused status — delivered only via ?exp= fetch' => [
+                '9002', 'paused-exp', ['status' => 'paused'],
+                [['id' => '9002-A', 'key' => 'a'], ['id' => '9002-B', 'key' => 'b']],
+                false, null, '9002-B', null,
+            ],
+            'mismatched environment — present in config under a different environment' => [
+                '9003', 'env-mismatch-exp', ['environment' => 'staging'],
+                [['id' => '9003-A', 'key' => 'a'], ['id' => '9003-B', 'key' => 'b']],
+                true, null, '9003-B', null,
+            ],
+            'non-running variation — sole variation is not RUNNING' => [
+                '9004', 'non-running-exp', [],
+                [['id' => '9004-A', 'key' => 'a', 'overrides' => ['status' => 'paused']]],
+                true, null, '9004-A', null,
+            ],
+            'zero-traffic variation — sole variation has traffic_allocation 0' => [
+                '9005', 'zero-traffic-exp', [],
+                [['id' => '9005-A', 'key' => 'a', 'overrides' => ['traffic_allocation' => 0]]],
+                true, null, '9005-A', null,
+            ],
+            'different stored decision — visitor already bucketed elsewhere' => [
+                '9006', 'stored-decision-exp', [],
+                [['id' => '9006-A', 'key' => 'a'], ['id' => '9006-B', 'key' => 'b']],
+                true, '9006-A', '9006-B', '9006-A',
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $experienceOverrides
+     * @param array<int, array<string, mixed>> $variationSpecs
+     */
+    #[DataProvider('bypassCasesProvider')]
+    public function testPreviewBypassesAllNormalGates(
+        string $experienceId,
+        string $experienceKey,
+        array $experienceOverrides,
+        array $variationSpecs,
+        bool $presentInBaseConfig,
+        ?string $seedStoredVariationId,
+        string $forcedVariationId,
+        ?string $expectedNormalVariationId
+    ): void {
+        $variations = array_map(
+            fn (array $spec) => $this->variation($spec['id'], $spec['key'], $spec['overrides'] ?? []),
+            $variationSpecs
+        );
+        $experience = $this->experienceFixture($experienceId, $experienceKey, $experienceOverrides, $variations);
+
+        $rig = $this->buildRig($presentInBaseConfig ? [$experience] : []);
+        if (!$presentInBaseConfig) {
+            $this->queueExpFetchResponse($experience);
+        }
+
+        $previewVisitorId = 'preview-visitor-' . $experienceId;
+        if ($seedStoredVariationId !== null) {
+            $rig['dataManager']->putData($previewVisitorId, ['bucketing' => [$experienceId => $seedStoredVariationId]]);
+        }
+
+        $previewContext = $rig['core']->createContext($previewVisitorId);
+        $previewContext->setPreview($experienceId, $forcedVariationId);
+        $decision = $previewContext->runExperience($experienceKey);
+
+        $this->assertInstanceOf(BucketedVariation::class, $decision, 'preview must force a decision regardless of the disabled gate');
+        $this->assertSame($forcedVariationId, $decision->variationId, 'preview must return the exact requested variation');
+        $this->assertSame($experienceId, $decision->experienceId);
+
+        if (!$presentInBaseConfig) {
+            $this->assertCount(1, $this->expRequestsFor($experienceId), 'AC4: exactly one ?exp= fetch expected when the experience is absent from the current config');
+        }
+
+        $normalVisitorId = $seedStoredVariationId !== null ? $previewVisitorId : 'normal-visitor-' . $experienceId;
+        $normalContext = $rig['core']->createContext($normalVisitorId);
+        $normalDecision = $normalContext->runExperience($experienceKey, new BucketingAttributes(self::NO_LOCATION_GATE));
+
+        if ($expectedNormalVariationId === null) {
+            $this->assertNull($normalDecision, 'non-preview evaluation must be blocked by the real gate this case exercises');
+        } else {
+            $this->assertInstanceOf(BucketedVariation::class, $normalDecision);
+            $this->assertSame($expectedNormalVariationId, $normalDecision->variationId, 'non-preview context must be unaffected by the preview override (preview must not have persisted anything)');
+        }
+    }
+
+    // -- AC6: zero trace across the full lifecycle, including shutdown -------------------
+
+    #[Test]
+    public function previewContextLeavesZeroTraceAcrossFullLifecycleIncludingShutdown(): void
+    {
+        $targetId = '9101';
+        $targetKey = 'shutdown-exp';
+        $experience = $this->experienceFixture($targetId, $targetKey, ['status' => 'draft'], [
+            $this->variation('9101-A', 'a'),
+            $this->variation('9101-B', 'b'),
+        ]);
+
+        $rig = $this->buildRig();
+        $this->queueExpFetchResponse($experience);
+
+        $context = $rig['core']->createContext('preview-visitor-ac6');
+        $context->setPreview($targetId, '9101-B');
+
+        $forced = $context->runExperience($targetKey);
+        $this->assertInstanceOf(BucketedVariation::class, $forced);
+        $this->assertSame('9101-B', $forced->variationId);
+
+        // A DIFFERENT experience on the SAME preview context must still decide
+        // normally (coherent rendering) — but the whole context is zero-trace, not
+        // just the forced target.
+        $other = $context->runExperience(self::OTHER_EXPERIENCE_KEY, new BucketingAttributes(self::NO_LOCATION_GATE));
+        $this->assertInstanceOf(BucketedVariation::class, $other, 'other experiences must still decide normally on a preview context');
+
+        $context->trackConversion(self::GOAL_KEY);
+
+        // Model the PHP-FPM shutdown handler ConvertSDK::create() registers.
+        $rig['apiManager']->releaseQueue('shutdown');
+
+        $this->assertSame([], $this->trackRequests(), 'zero requests to the track endpoint across the full preview-context lifecycle, including shutdown flush');
+        $this->assertSame(0, $rig['dataStore']->setCalls, 'zero visitor-state dataStore writes across the full preview-context lifecycle');
+    }
+
+    // -- AC7: isolation from a concurrent non-preview context ----------------------------
+
+    #[Test]
+    public function concurrentNonPreviewContextTracksAndPersistsNormallyOnSharedManagers(): void
+    {
+        $targetId = '9102';
+        $targetKey = 'concurrent-exp';
+        $experience = $this->experienceFixture($targetId, $targetKey, ['status' => 'draft'], [
+            $this->variation('9102-A', 'a'),
+            $this->variation('9102-B', 'b'),
+        ]);
+
+        $rig = $this->buildRig();
+        $this->queueExpFetchResponse($experience);
+
+        $previewContext = $rig['core']->createContext('preview-visitor-ac7');
+        $previewContext->setPreview($targetId, '9102-B');
+        $previewContext->runExperience($targetKey);
+        $previewContext->trackConversion(self::GOAL_KEY);
+
+        // Concurrent NON-preview context on the SAME Core/managers (same ApiManager
+        // queue, same DataManager, same dataStore/cache) must be unaffected.
+        $normalContext = $rig['core']->createContext('normal-visitor-ac7');
+        $normalDecision = $normalContext->runExperience(self::OTHER_EXPERIENCE_KEY, new BucketingAttributes(self::NO_LOCATION_GATE));
+        $normalContext->trackConversion(self::GOAL_KEY);
+
+        $rig['apiManager']->releaseQueue('shutdown');
+
+        $this->assertInstanceOf(BucketedVariation::class, $normalDecision);
+        $this->assertGreaterThan(0, $rig['dataStore']->setCalls, 'the concurrent non-preview context must persist visitor state normally');
+        $this->assertNotEmpty($this->trackRequests(), 'the concurrent non-preview context must still send tracking requests');
+    }
+
+    // -- AC8: memoization ------------------------------------------------------------------
+
+    #[Test]
+    public function twoPreviewResolutionsWithinSixtySecondsCauseExactlyOneOriginFetchViaPreviewScopedKey(): void
+    {
+        $targetId = '9103';
+        $targetKey = 'memo-exp';
+        $experience = $this->experienceFixture($targetId, $targetKey, ['status' => 'draft'], [
+            $this->variation('9103-A', 'a'),
+            $this->variation('9103-B', 'b'),
+        ]);
+
+        $rig = $this->buildRig();
+        // Exactly ONE response queued — a second fetch would fall through to the
+        // mock client's default empty-200 response, which the assertions below
+        // would catch via the raw request count (not via queue exhaustion).
+        $this->queueExpFetchResponse($experience);
+
+        $firstContext = $rig['core']->createContext('preview-visitor-ac8-a');
+        $firstContext->setPreview($targetId, '9103-B');
+        $firstDecision = $firstContext->runExperience($targetKey);
+
+        $secondContext = $rig['core']->createContext('preview-visitor-ac8-b');
+        $secondContext->setPreview($targetId, '9103-B');
+        $secondDecision = $secondContext->runExperience($targetKey);
+
+        $this->assertInstanceOf(BucketedVariation::class, $firstDecision);
+        $this->assertInstanceOf(BucketedVariation::class, $secondDecision);
+        $this->assertSame('9103-B', $firstDecision->variationId);
+        $this->assertSame('9103-B', $secondDecision->variationId);
+
+        $this->assertCount(1, $this->expRequestsFor($targetId), 'two preview resolutions for the same experience within 60s must cause exactly one origin fetch');
+
+        $recordedKeys = array_column($rig['cache']->calls, 'key');
+        $this->assertContains('preview_' . $targetId, $recordedKeys, 'memoization must use the preview-scoped key preview_{experienceId}');
+        foreach ($recordedKeys as $key) {
+            $this->assertStringNotContainsString('convert_sdk.config.', $key, 'preview memoization must never use the normal config cache key');
+        }
+    }
+}

--- a/packages/Php-sdk/tests/Preview/ContextPreviewTest.php
+++ b/packages/Php-sdk/tests/Preview/ContextPreviewTest.php
@@ -13,6 +13,7 @@ use ConvertSdk\DTO\BucketedVariation;
 use ConvertSdk\Event\EventManager;
 use ConvertSdk\ExperienceManager;
 use ConvertSdk\FeatureManager;
+use ConvertSdk\Interfaces\ExperienceManagerInterface;
 use ConvertSdk\Interfaces\SegmentsManagerInterface;
 use ConvertSdk\LogManager;
 use ConvertSdk\RuleManager;
@@ -198,10 +199,19 @@ class ContextPreviewTest extends TestCase
      *
      * @param array<int, array<string, mixed>> $extraExperiences
      * @param array<int, array<string, mixed>> $features
+     * @param ExperienceManagerInterface|null $experienceManagerOverride Substitutes a
+     *     test double for the real ExperienceManager — used only by tests that need to
+     *     synthesize a bucketedVariations shape the real manager can never produce (e.g.
+     *     an entry missing `experienceKey`), while keeping DataManager/ApiManager real so
+     *     {@see \ConvertSdk\Context::setPreview()}'s resolution/persistence still exercises
+     *     genuine code.
      * @return array{core: Core, dataManager: DataManager, apiManager: ApiManager, cache: RecordingCache, dataStore: RecordingDataStore}
      */
-    private function buildRig(array $extraExperiences = [], array $features = []): array
-    {
+    private function buildRig(
+        array $extraExperiences = [],
+        array $features = [],
+        ?ExperienceManagerInterface $experienceManagerOverride = null
+    ): array {
         $data = new ConfigResponseData([
             'account_id' => 'acct-1',
             'project' => ['id' => 'proj-1'],
@@ -244,7 +254,7 @@ class ContextPreviewTest extends TestCase
         $dataStore = new RecordingDataStore();
         $dataManager->setDataStore($dataStore);
 
-        $experienceManager = new ExperienceManager(dataManager: $dataManager);
+        $experienceManager = $experienceManagerOverride ?? new ExperienceManager(dataManager: $dataManager);
         $featureManager = new FeatureManager(dataManager: $dataManager);
         $cache = new RecordingCache();
 
@@ -550,6 +560,68 @@ class ContextPreviewTest extends TestCase
         $this->assertArrayHasKey($targetKey, $byKey, 'the in-config running preview target must still appear in the bulk result');
         $this->assertSame('9106-B', $byKey[$targetKey]->variationId, 'preview forcing must beat the stored decision for the target experience in the bulk method too (contract §3, method-agnostic)');
         $this->assertArrayHasKey(self::OTHER_EXPERIENCE_KEY, $byKey, 'other experiences must still decide normally on a preview context');
+    }
+
+    /**
+     * Gemini PR #51 review finding (correctness): before the fix, the bulk
+     * injection loop sourced `$previewKey` from `$this->previewExperience['key']
+     * ?? null` with no guard — when the preview target's raw config data is
+     * missing `key` (malformed/legacy data; {@see ConfigExperience::getKey()}
+     * defaults to `null` when unset), `$previewKey` resolves to `null`. Any
+     * OTHER bucketed variation entry whose own `experienceKey` is also
+     * missing/null would then spuriously satisfy `null === null` and get
+     * overwritten with the preview decision — even though it has nothing to
+     * do with the preview target.
+     *
+     * The real {@see \ConvertSdk\ExperienceManager::selectVariations()} can
+     * never itself produce an entry with a missing `experienceKey` (it always
+     * sets it from the `string $experienceKey` it was called with), so this
+     * synthesizes that shape via a mocked ExperienceManager to exercise the
+     * defensive guard directly. Fixed code sources the key from
+     * `$this->previewDecision['experienceKey']` (the authoritative key
+     * {@see \ConvertSdk\DataManager::buildPreviewDecision()} derives from
+     * `ConfigExperience::getKey()`) and skips injection entirely when it is
+     * null/empty — this test's target experience has the same "no key"
+     * defect, so both sourcing approaches agree here; the guard itself is
+     * what's under test.
+     */
+    #[Test]
+    public function nullPreviewKeyDoesNotOverwriteABucketedVariationWithMissingExperienceKey(): void
+    {
+        $targetId = '9107';
+        // Deliberately no 'key' field — ConfigExperience::getKey() returns
+        // null for it, so previewDecision['experienceKey'] is null too.
+        $targetWithNoKey = [
+            'id' => $targetId,
+            'status' => 'running',
+            'variations' => [
+                $this->variation($targetId . '-A', 'a'),
+            ],
+        ];
+
+        $unrelatedVariationId = 'unrelated-exp-A';
+        $spy = $this->createMock(ExperienceManagerInterface::class);
+        $spy->method('selectVariations')->willReturn([
+            // No 'experienceKey' entry at all — the shape a real
+            // ExperienceManager can never produce, but the guard must
+            // still defend against it.
+            ['id' => $unrelatedVariationId, 'key' => 'a', 'changes' => []],
+        ]);
+
+        $rig = $this->buildRig([$targetWithNoKey], [], $spy);
+
+        $context = $rig['core']->createContext('preview-visitor-null-key');
+        $context->setPreview($targetId, $targetId . '-A');
+
+        $decisions = $context->runExperiences();
+
+        $this->assertCount(1, $decisions);
+        $this->assertSame(
+            $unrelatedVariationId,
+            $decisions[0]->variationId,
+            'a bucketed variation with a missing experienceKey must not be overwritten by the preview decision when the preview key itself is null/empty'
+        );
+        $this->assertSame('', $decisions[0]->experienceKey);
     }
 
     // -- AC6: zero trace across the full lifecycle, including shutdown -------------------

--- a/packages/Php-sdk/tests/Preview/ContextPreviewTest.php
+++ b/packages/Php-sdk/tests/Preview/ContextPreviewTest.php
@@ -8,10 +8,11 @@ use ConvertSdk\ApiManager;
 use ConvertSdk\BucketingManager;
 use ConvertSdk\Core;
 use ConvertSdk\DataManager;
+use ConvertSdk\DTO\BucketedFeature;
 use ConvertSdk\DTO\BucketedVariation;
 use ConvertSdk\Event\EventManager;
 use ConvertSdk\ExperienceManager;
-use ConvertSdk\Interfaces\FeatureManagerInterface;
+use ConvertSdk\FeatureManager;
 use ConvertSdk\Interfaces\SegmentsManagerInterface;
 use ConvertSdk\LogManager;
 use ConvertSdk\RuleManager;
@@ -165,6 +166,17 @@ class ContextPreviewTest extends TestCase
     private const OTHER_EXPERIENCE_KEY = 'other-exp';
     private const GOAL_KEY = 'preview-goal';
     private const NO_LOCATION_GATE = ['ignoreLocationProperties' => true];
+    private const FEATURE_ID = '20001';
+    private const FEATURE_KEY = 'preview-feature';
+    private const FEATURE_EXPERIENCE_ID = '9105';
+    private const FEATURE_EXPERIENCE_KEY = 'feature-carrying-exp';
+    /** Non-empty location properties so the location-agnostic fixtures (no
+     * `locations`/`site_area`) fall into matchRulesByField()'s "not restricted"
+     * branch and actually reach the bucketing/persistence code — required so a
+     * zero-trace regression test genuinely exercises the write path instead of
+     * short-circuiting on the location gate before it ever would.
+     */
+    private const LOCATION_PROPERTIES = ['locationProperties' => ['url' => 'https://convert.com/']];
 
     private MockHttpClient $mockHttpClient;
     private Psr17Factory $psr17Factory;
@@ -185,14 +197,16 @@ class ContextPreviewTest extends TestCase
      * current config" per qs-02 contract §2, needing no ?exp= fetch.
      *
      * @param array<int, array<string, mixed>> $extraExperiences
+     * @param array<int, array<string, mixed>> $features
      * @return array{core: Core, dataManager: DataManager, apiManager: ApiManager, cache: RecordingCache, dataStore: RecordingDataStore}
      */
-    private function buildRig(array $extraExperiences = []): array
+    private function buildRig(array $extraExperiences = [], array $features = []): array
     {
         $data = new ConfigResponseData([
             'account_id' => 'acct-1',
             'project' => ['id' => 'proj-1'],
             'experiences' => array_merge([$this->otherExperience()], $extraExperiences),
+            'features' => $features,
             'goals' => [
                 ['id' => '7001', 'key' => self::GOAL_KEY, 'name' => 'Preview Goal', 'rules' => null],
             ],
@@ -231,6 +245,7 @@ class ContextPreviewTest extends TestCase
         $dataManager->setDataStore($dataStore);
 
         $experienceManager = new ExperienceManager(dataManager: $dataManager);
+        $featureManager = new FeatureManager(dataManager: $dataManager);
         $cache = new RecordingCache();
 
         $core = new Core(
@@ -238,7 +253,7 @@ class ContextPreviewTest extends TestCase
             $dataManager,
             $eventManager,
             $experienceManager,
-            $this->createMock(FeatureManagerInterface::class),
+            $featureManager,
             $this->createMock(SegmentsManagerInterface::class),
             $apiManager,
             $cache,
@@ -275,6 +290,45 @@ class ContextPreviewTest extends TestCase
                 $this->variation(self::OTHER_EXPERIENCE_ID . '-B', 'b'),
             ],
         ];
+    }
+
+    /**
+     * A feature declaration paired with {@see featureCarryingExperience()} — used to prove
+     * the Context::runFeature()/runFeatures() zero-trace regression (qs-02 decision-audit
+     * Defect 1/2): these methods bucket EVERY experience in the config (not just a
+     * targeted one), so a leak here would persist/track for an experience the caller
+     * never even named.
+     *
+     * @return array<string, mixed>
+     */
+    private function featureFixture(): array
+    {
+        return [
+            'id' => self::FEATURE_ID,
+            'key' => self::FEATURE_KEY,
+            'name' => 'Preview Feature',
+            'variables' => [],
+        ];
+    }
+
+    /**
+     * A location/audience-agnostic, always-decidable experience carrying a fullStackFeature
+     * change linked to {@see featureFixture()} — present in the base config (like
+     * {@see otherExperience()}) so Context::runFeature()/runFeatures() bucket it as part of
+     * their "iterate every experience in config" sweep.
+     *
+     * @return array<string, mixed>
+     */
+    private function featureCarryingExperience(): array
+    {
+        return $this->experienceFixture(self::FEATURE_EXPERIENCE_ID, self::FEATURE_EXPERIENCE_KEY, [], [
+            $this->variation(self::FEATURE_EXPERIENCE_ID . '-A', 'a', [
+                'changes' => [['id' => 'chg-feat-a', 'type' => 'fullStackFeature', 'data' => ['feature_id' => self::FEATURE_ID]]],
+            ]),
+            $this->variation(self::FEATURE_EXPERIENCE_ID . '-B', 'b', [
+                'changes' => [['id' => 'chg-feat-b', 'type' => 'fullStackFeature', 'data' => ['feature_id' => self::FEATURE_ID]]],
+            ]),
+        ]);
     }
 
     /**
@@ -458,6 +512,46 @@ class ContextPreviewTest extends TestCase
         }
     }
 
+    // -- §3 precedence: the bulk method must also honor preview forcing ------------------
+
+    /**
+     * qs-02 decision-audit remediation, Defect 3: contract §3 ("preview forcing beats
+     * stored decisions and normal bucketing for the target experience on that context")
+     * is method-agnostic — runExperiences() must honor it for an in-config, running,
+     * environment-matching preview target, not just runExperience(). Seeds a stored
+     * decision (mirroring the 'different stored decision' bypassCasesProvider() case)
+     * so the un-forced bulk result is deterministic, proving the override — not hash
+     * luck — is what makes the assertion pass.
+     */
+    #[Test]
+    public function previewForcingOverridesTheTargetExperienceInBulkRunExperiences(): void
+    {
+        $targetId = '9106';
+        $targetKey = 'bulk-precedence-exp';
+        $target = $this->experienceFixture($targetId, $targetKey, [], [
+            $this->variation('9106-A', 'a'),
+            $this->variation('9106-B', 'b'),
+        ]);
+
+        $rig = $this->buildRig([$target]);
+        $visitorId = 'preview-visitor-bulk-precedence';
+        $rig['dataManager']->putData($visitorId, ['bucketing' => [$targetId => '9106-A']]);
+
+        $context = $rig['core']->createContext($visitorId);
+        $context->setPreview($targetId, '9106-B');
+
+        $decisions = $context->runExperiences(new BucketingAttributes(self::NO_LOCATION_GATE));
+
+        $byKey = [];
+        foreach ($decisions as $decision) {
+            $byKey[$decision->experienceKey] = $decision;
+        }
+
+        $this->assertArrayHasKey($targetKey, $byKey, 'the in-config running preview target must still appear in the bulk result');
+        $this->assertSame('9106-B', $byKey[$targetKey]->variationId, 'preview forcing must beat the stored decision for the target experience in the bulk method too (contract §3, method-agnostic)');
+        $this->assertArrayHasKey(self::OTHER_EXPERIENCE_KEY, $byKey, 'other experiences must still decide normally on a preview context');
+    }
+
     // -- AC6: zero trace across the full lifecycle, including shutdown -------------------
 
     #[Test]
@@ -493,6 +587,47 @@ class ContextPreviewTest extends TestCase
 
         $this->assertSame([], $this->trackRequests(), 'zero requests to the track endpoint across the full preview-context lifecycle, including shutdown flush');
         $this->assertSame(0, $rig['dataStore']->setCalls, 'zero visitor-state dataStore writes across the full preview-context lifecycle');
+    }
+
+    /**
+     * qs-02 decision-audit remediation, Defect 1/2: Context::runFeature()/runFeatures() must
+     * be just as zero-trace as runExperience()/runExperiences() on a preview-set context.
+     * These feature methods bucket EVERY experience in the config (FeatureManager::runFeatures()
+     * has no experience filter by default), so calling either one on a preview context leaks
+     * persistence/tracking for every not-yet-bucketed experience unless suppressPersistence is
+     * forwarded — exactly the gap the original AC6 test missed by mocking FeatureManager instead
+     * of exercising the real bucketing path.
+     */
+    #[Test]
+    public function previewContextLeavesZeroTraceAcrossFeatureMethodsIncludingShutdown(): void
+    {
+        $targetId = '9104';
+        $targetKey = 'feature-preview-target-exp';
+        $target = $this->experienceFixture($targetId, $targetKey, ['status' => 'draft'], [
+            $this->variation('9104-A', 'a'),
+            $this->variation('9104-B', 'b'),
+        ]);
+
+        $rig = $this->buildRig([$this->featureCarryingExperience()], [$this->featureFixture()]);
+        $this->queueExpFetchResponse($target);
+
+        $context = $rig['core']->createContext('preview-visitor-feature');
+        $context->setPreview($targetId, '9104-B');
+
+        $forced = $context->runExperience($targetKey);
+        $this->assertInstanceOf(BucketedVariation::class, $forced, 'preview target must still force its decision');
+
+        $feature = $context->runFeature(self::FEATURE_KEY, new BucketingAttributes(self::LOCATION_PROPERTIES));
+        $this->assertInstanceOf(BucketedFeature::class, $feature, 'the feature-carrying experience must actually bucket, not be blocked by a gate — otherwise this test would pass trivially');
+
+        $features = $context->runFeatures(new BucketingAttributes(self::LOCATION_PROPERTIES));
+        $this->assertNotEmpty($features, 'runFeatures() must actually bucket experiences, not be blocked by a gate — otherwise this test would pass trivially');
+
+        // Model the PHP-FPM shutdown handler ConvertSDK::create() registers.
+        $rig['apiManager']->releaseQueue('shutdown');
+
+        $this->assertSame([], $this->trackRequests(), 'zero requests to the track endpoint after runFeature()/runFeatures() on a preview context, including shutdown flush');
+        $this->assertSame(0, $rig['dataStore']->setCalls, 'zero visitor-state dataStore writes after runFeature()/runFeatures() on a preview context');
     }
 
     // -- AC7: isolation from a concurrent non-preview context ----------------------------

--- a/packages/Php-sdk/tests/Preview/PreviewParamTest.php
+++ b/packages/Php-sdk/tests/Preview/PreviewParamTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConvertSdk\Tests\Preview;
+
+use ConvertSdk\Preview\PreviewParam;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * qs-02 capability (B) preview input — AC9: the pure static `convert_preview`
+ * link-param parser.
+ *
+ * Contract §2: "Canonical link format ... convert_preview={experienceId}.
+ * {variationId} — dot-separated numeric ids, mirroring the web force-param
+ * format `_conv_eforce={expId}.{varId}`. The SDK SHOULD ship a pure static
+ * helper (e.g. PreviewParam::parse(string $value): ?array)."
+ *
+ * Decision (qs-02 decision log): the parsed pair is returned as an associative
+ * array `['experienceId' => string, 'variationId' => string]` rather than a
+ * positional tuple — the spec leaves the exact return shape open, and an
+ * associative array reads directly into
+ * `$context->setPreview($parsed['experienceId'], $parsed['variationId'])`
+ * without a positional-index footgun.
+ *
+ * RED-phase note (qs-02 PHP-2, TDD RED): `ConvertSdk\Preview\PreviewParam` does
+ * not exist yet. Every test below is expected to fail with
+ * `Error: Class "ConvertSdk\Preview\PreviewParam" not found` until the PHP-2
+ * GREEN implementation lands.
+ *
+ * @see ../../../../../ai-driven-product-dev/_bmad-output/planning-artifacts/2026-03-13-convert-php-sdk/qs-02-experiment-preview.md
+ */
+class PreviewParamTest extends TestCase
+{
+    #[Test]
+    public function parseReturnsExperienceAndVariationIdPairForAWellFormedValue(): void
+    {
+        $result = PreviewParam::parse('123.456');
+
+        $this->assertSame(['experienceId' => '123', 'variationId' => '456'], $result);
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function malformedValueProvider(): array
+    {
+        return [
+            'no dot separator' => ['123456'],
+            'too many dots' => ['123.456.789'],
+            'non-numeric experienceId' => ['abc.456'],
+            'non-numeric variationId' => ['123.abc'],
+            'empty string' => [''],
+            'empty experienceId segment' => ['.456'],
+            'empty variationId segment' => ['123.'],
+            'negative experienceId' => ['-123.456'],
+            'whitespace around ids' => [' 123.456 '],
+            'trailing garbage after variationId' => ['123.456abc'],
+        ];
+    }
+
+    #[DataProvider('malformedValueProvider')]
+    public function testParseReturnsNullForMalformedValue(string $value): void
+    {
+        $this->assertNull(PreviewParam::parse($value));
+    }
+}

--- a/packages/Types/lib/BucketingAttributes.php
+++ b/packages/Types/lib/BucketingAttributes.php
@@ -59,6 +59,19 @@ class BucketingAttributes
     public $ignoreLocationProperties;
 
     /**
+     * qs-02 capability (B) preview input — per-context suppression signal.
+     * When true, DataManager suppresses ALL visitor-state persistence writes
+     * (putData()) and ALL tracking-event enqueues for this call, regardless of
+     * `enableTracking` (which only gates the bucketing-event enqueue, not
+     * persistence). Set by Context on every forwarded call once
+     * `setPreview()` has resolved successfully — never exposed as a public
+     * per-call override.
+     *
+     * @var bool|null
+     */
+    public $suppressPersistence;
+
+    /**
      * Constructor to initialize the object with data.
      *
      * @param array $data Associative array of property values
@@ -74,6 +87,7 @@ class BucketingAttributes
         $this->forceVariationId = $data['forceVariationId'] ?? null;
         $this->enableTracking = $data['enableTracking'] ?? null;
         $this->ignoreLocationProperties = $data['ignoreLocationProperties'] ?? null;
+        $this->suppressPersistence = $data['suppressPersistence'] ?? null;
     }
 
     /**
@@ -271,6 +285,28 @@ class BucketingAttributes
     public function setIgnoreLocationProperties(?bool $ignoreLocationProperties): self
     {
         $this->ignoreLocationProperties = $ignoreLocationProperties;
+        return $this;
+    }
+
+    /**
+     * Get whether visitor-state persistence and tracking enqueues are suppressed.
+     *
+     * @return bool|null
+     */
+    public function getSuppressPersistence(): ?bool
+    {
+        return $this->suppressPersistence;
+    }
+
+    /**
+     * Set whether visitor-state persistence and tracking enqueues are suppressed.
+     *
+     * @param bool|null $suppressPersistence
+     * @return self
+     */
+    public function setSuppressPersistence(?bool $suppressPersistence): self
+    {
+        $this->suppressPersistence = $suppressPersistence;
         return $this;
     }
 }

--- a/packages/Types/lib/Config.php
+++ b/packages/Types/lib/Config.php
@@ -49,6 +49,15 @@ class Config
     /** @var ?string Optional SDK key secret */
     private ?string $sdkKeySecret = null;
 
+    /**
+     * Optional QA/preview debug token (qs-02 capability A). When set, every
+     * config-fetch URL carries `debug_token=<value>` and `_conv_low_cache=1`
+     * (forced), and the SDK-side config cache is bypassed entirely.
+     *
+     * @var ?string
+     */
+    private ?string $debugToken = null;
+
     /** @var ?ConfigResponseData Configuration data from API */
     private ?ConfigResponseData $data = null;
 
@@ -105,6 +114,9 @@ class Config
         $this->logger = isset($options['logger']) && is_array($options['logger']) ? $options['logger'] : null;
         $this->network = isset($options['network']) && is_array($options['network']) ? $options['network'] : null;
         $this->mapper = isset($options['mapper']) && is_callable($options['mapper']) ? $options['mapper'] : null;
+        $this->debugToken = isset($options['debugToken']) && is_string($options['debugToken']) && $options['debugToken'] !== ''
+            ? $options['debugToken']
+            : null;
     }
 
     // Getters
@@ -168,6 +180,11 @@ class Config
     public function getSdkKeySecret(): ?string
     {
         return $this->sdkKeySecret;
+    }
+
+    public function getDebugToken(): ?string
+    {
+        return $this->debugToken;
     }
 
     public function getData(): ?ConfigResponseData

--- a/packages/Types/lib/LocationAttributes.php
+++ b/packages/Types/lib/LocationAttributes.php
@@ -31,6 +31,16 @@ class LocationAttributes
     protected $forceEvent;
 
     /**
+     * qs-02 capability (B) preview input — mirrors
+     * {@see \OpenAPI\Client\BucketingAttributes::$suppressPersistence}. When
+     * true, {@see \ConvertSdk\DataManager::selectLocations()} suppresses its
+     * visitor-state persistence write.
+     *
+     * @var bool|null
+     */
+    protected $suppressPersistence;
+
+    /**
      * Constructor to initialize the object with data.
      *
      * @param array $data Associative array of property values
@@ -47,6 +57,7 @@ class LocationAttributes
         $this->identityField = $identityField;
 
         $this->forceEvent = $data['forceEvent'] ?? null;
+        $this->suppressPersistence = $data['suppressPersistence'] ?? null;
     }
 
     /**
@@ -116,6 +127,28 @@ class LocationAttributes
     public function setForceEvent(?bool $forceEvent): self
     {
         $this->forceEvent = $forceEvent;
+        return $this;
+    }
+
+    /**
+     * Get whether visitor-state persistence is suppressed.
+     *
+     * @return bool|null
+     */
+    public function getSuppressPersistence(): ?bool
+    {
+        return $this->suppressPersistence;
+    }
+
+    /**
+     * Set whether visitor-state persistence is suppressed.
+     *
+     * @param bool|null $suppressPersistence
+     * @return self
+     */
+    public function setSuppressPersistence(?bool $suppressPersistence): self
+    {
+        $this->suppressPersistence = $suppressPersistence;
         return $this;
     }
 }


### PR DESCRIPTION
## Summary

Adds the **qs-02 Experiment Preview** feature to the PHP SDK — an additive, non-breaking capability with two independent parts. No API/OpenAPI/backend work: both serving primitives (`?exp=`, `?debug_token=`) already exist live.

**A. `debugToken` config option** — when set, appends `debug_token=<token>` + a forced `_conv_low_cache=1` to the config fetch, disables the SDK-side PSR-16 config cache while active, redacts the token from all logs (including inside PSR-18 exception messages), and never sends it to the track endpoint.

**B. Preview input** — `$context->setPreview(experienceId, variationId)` force-decides that variation, bypassing rules / environment / status / bucketing / stored-decisions. When the experience is absent from the loaded config it is fetched via `?exp=` (memoized 60s under a preview-scoped cache key). A hard **zero-trace** guarantee holds for the whole preview context: no tracking events and no visitor-state writes, including at shutdown flush. Ships `PreviewParam::parse()` for the canonical `convert_preview={expId}.{varId}` link format. Bad input is inert — a failed preview resumes normal tracking.

> **Stacked PR.** Base is `feat/anchored-bucketing-layout` (tip `b044c4f`), **not** `main`. Branch is 0 commits behind / 6 ahead of the base.

## Acceptance criteria

- **AC1–AC3** (debugToken): transport (`debug_token` + forced `_conv_low_cache=1`), config-cache elimination while set, token hygiene (redacted in endpoint logs and PSR-18 exception messages; never in the track payload).
- **AC4–AC10** (preview): forced decision, full six-case bypass, zero-trace incl. shutdown flush, per-context isolation on the shared-singleton managers, `?exp=` fetch + 60s memoization, `PreviewParam::parse`, full-suite regression lock.

## Tasks

- `[PHP-1]` debugToken config option — QA config transport, cache elimination, token hygiene (`ai-driven-product-dev-wxmk`)
- `[PHP-2]` Preview input — force-decision, zero-trace, `?exp=` fetch + memoization, `PreviewParam::parse` (`ai-driven-product-dev-1y2b`)
- `[PHP-fix]` Review R1: redact `debug_token` leaking via unredacted PSR-18 exception messages (`ai-driven-product-dev-f808`)

## Quality gates

- Full suite **1132 pass / 0 fail** (34 pre-existing skips)
- **PHPStan L6 clean**, **php-cs-fixer clean**
- php-sdk has no SonarCloud gate
- Independent decision audit (analyst → auditor, fresh context each round): **PASS** after one remediation round — a §2 zero-trace feature-path leak (`runFeature`/`runFeatures` omitting `suppressPersistence` when preview was set) was found and fixed with a real-`FeatureManager` regression test locking it across shutdown flush.
- Code review: **clean** after round 2 (the AC3 PSR-18 exception-message redaction gap was the one actionable finding, resolved).

## Accepted out-of-scope note (not a defect)

The decision auditors flagged and then ruled **out of scope** a §2 wording tension: the spec's literal "ALL writes" vs. the imperative, app-commanded `updateVisitorProperties` / `setDefaultSegments` / `runCustomSegments` and constructor segment-seeding, which write to `dataStore` unguarded by preview. These are pre-existing, app-commanded writes — not decisioning side-effects — and AC6's lifecycle plus the pre-`setPreview` constructor write show §2's intent is decisioning-scoped. Per maintainer decision this is **accepted as-is**: no spec change and no follow-up. Recorded here as a decisioning-scoped clarification, **not an open defect in this delivery**.

## Test plan

- [ ] `debugToken` set → config fetch carries `debug_token` + `_conv_low_cache=1`; PSR-16 config cache bypassed; token absent from logs and track payload
- [ ] `setPreview` forces the target variation across all six bypass cases; `?exp=` fetch memoized 60s; zero tracking/visitor-state writes through shutdown flush
- [ ] `PreviewParam::parse` round-trips `convert_preview={expId}.{varId}`; malformed input resumes normal tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)
