### PR TITLE
feat(rules): mutual-exclusion audience rule (bucketed_into_experience_key)

### DIFF
--- a/packages/Data/src/DataManager.php
+++ b/packages/Data/src/DataManager.php
@@ -430,7 +430,13 @@ final class DataManager implements DataManagerInterface
                 if (count($audiencesToCheck) > 0) {
                     $matchedAudiences = $this->filterMatchedRecordsWithRule(
                         $audiencesToCheck,
-                        $visitorProperties,
+                        // qs-03 gate widening (line 425) can reach this call with
+                        // $visitorProperties still null (no caller-supplied
+                        // properties at all). Coerce to [] here: the exclusion
+                        // path reads stored bucketing state via getData(), not
+                        // visitorProperties content, so an empty array is a safe,
+                        // behavior-preserving default (Gemini review R1).
+                        $visitorProperties ?? [],
                         'audience',
                         $identityField,
                         $visitorId
@@ -1410,7 +1416,7 @@ final class DataManager implements DataManagerInterface
                 // never modified (AC7); any item whose rule tree is NOT a sole
                 // bucketed_into_experience_key rule (every generic key/value rule shape
                 // in production today) is passed through completely unchanged below.
-                $exclusionRule = $visitorId !== null
+                $exclusionRule = ($visitorId !== null && is_array($item['rules']))
                     ? $this->_findSoleBucketedIntoExperienceKeyRule($item['rules'])
                     : null;
 
@@ -1460,7 +1466,7 @@ final class DataManager implements DataManagerInterface
     private function _audiencesContainBucketedIntoExperienceKeyRule(array $audiences): bool
     {
         foreach ($audiences as $audience) {
-            if (!empty($audience['rules']) && $this->_findSoleBucketedIntoExperienceKeyRule($audience['rules']) !== null) {
+            if (!empty($audience['rules']) && is_array($audience['rules']) && $this->_findSoleBucketedIntoExperienceKeyRule($audience['rules']) !== null) {
                 return true;
             }
         }
@@ -1540,7 +1546,7 @@ final class DataManager implements DataManagerInterface
         } else {
             $visitorData = $this->getData($visitorId) ?? [];
             $bucketingData = $visitorData['bucketing'] ?? [];
-            $bucketedRaw = array_key_exists((string)$target['id'], $bucketingData);
+            $bucketedRaw = array_key_exists((string)($target['id'] ?? ''), $bucketingData);
         }
 
         $syntheticKey = '__convertSdk_bucketedIntoExperienceKey';

--- a/packages/Data/src/DataManager.php
+++ b/packages/Data/src/DataManager.php
@@ -16,6 +16,7 @@ use ConvertSdk\Enums\DataEntities;
 use ConvertSdk\Enums\ErrorMessages;
 use ConvertSdk\Enums\Messages;
 use ConvertSdk\Enums\RuleError;
+use ConvertSdk\Enums\RuleType;
 use ConvertSdk\Enums\SystemEvents;
 use ConvertSdk\Event\Interfaces\EventManagerInterface;
 use ConvertSdk\Interfaces\ApiManagerInterface;
@@ -405,10 +406,23 @@ final class DataManager implements DataManagerInterface
         $segmentsMatched = false;
 
         if (isset($experience['audiences']) && is_array($experience['audiences']) && count($experience['audiences']) > 0) {
+            // Hoisted above the visitorProperties gate below: getItemsByIds() is a
+            // pure config lookup (no side effects), so fetching it unconditionally
+            // lets us inspect the fetched audiences' rule trees for a
+            // bucketed_into_experience_key rule (qs-03) before deciding whether the
+            // empty-visitorProperties gate applies.
+            $audiences = $this->getItemsByIds($experience['audiences'], 'audiences');
+            // qs-03 (mutual-exclusion audience rule): a bucketed_into_experience_key
+            // rule resolves against SDK-stored visitor bucketing state, not
+            // caller-supplied visitor properties, so it must still be evaluated when
+            // $visitorProperties is empty (AC4 "zero new application inputs").
+            $hasBucketingExclusionAudience = $this->_audiencesContainBucketedIntoExperienceKeyRule($audiences);
             // In PHP, an empty array [] is falsy (unlike JS where {} is truthy).
-            // This check correctly requires non-empty visitorProperties to evaluate audience rules.
-            if ($visitorProperties) {
-                $audiences = $this->getItemsByIds($experience['audiences'], 'audiences');
+            // This check correctly requires non-empty visitorProperties to evaluate audience rules
+            // -- UNLESS the audience carries a bucketed_into_experience_key rule, which reads
+            // stored bucketing state instead of visitor properties (qs-03 AC4). Generic-only
+            // audiences (no such rule) keep today's exact gate behavior (AC7).
+            if ($visitorProperties || $hasBucketingExclusionAudience) {
                 $audiencesToCheck = array_filter(
                     $audiences,
                     fn ($audience) => !($isBucketed && $audience['type'] === ConfigAudienceTypes::PERMANENT)
@@ -418,7 +432,8 @@ final class DataManager implements DataManagerInterface
                         $audiencesToCheck,
                         $visitorProperties,
                         'audience',
-                        $identityField
+                        $identityField,
+                        $visitorId
                     );
                     $matchedErrors = array_filter($matchedAudiences, fn ($match) => $match instanceof RuleError);
                     if (count($matchedErrors) > 0) {
@@ -443,8 +458,9 @@ final class DataManager implements DataManagerInterface
                     );
                 }
             }
-            // If visitorProperties is null/empty and experience has audiences,
-            // audiencesMatched stays false — can't evaluate without properties
+            // If visitorProperties is null/empty, no bucketed_into_experience_key
+            // audience is present, and the experience has (other) audiences,
+            // audiencesMatched stays false — can't evaluate without properties.
         } else {
             // No audiences on experience — all visitors qualify
             $audiencesMatched = true;
@@ -1352,13 +1368,18 @@ final class DataManager implements DataManagerInterface
      * @param array $visitorProperties Associative array of visitor properties
      * @param string $entityType Type of entity being filtered (e.g., 'audience')
      * @param string $field Identity field to use, defaults to 'id'
+     * @param string|null $visitorId qs-03: required only when an item's rule tree is a
+     *     sole bucketed_into_experience_key rule, to resolve against SDK-stored
+     *     visitor bucketing state instead of $visitorProperties. Null for callers
+     *     that never carry such a rule (RuleManager path is untouched for them).
      * @return array Array of matched items or RuleError instances
      */
     public function filterMatchedRecordsWithRule(
         array $items,
         array $visitorProperties,
         string $entityType,
-        string $field = IdentityField::ID
+        string $field = IdentityField::ID,
+        ?string $visitorId = null
     ): array {
         $this->_loggerManager?->trace(
             'DataManager.filterMatchedRecordsWithRule()',
@@ -1377,11 +1398,36 @@ final class DataManager implements DataManagerInterface
                     continue;
                 }
 
-                $match = $this->_ruleManager->isRuleMatched(
-                    $visitorProperties,
-                    new RuleObject($item['rules']),
-                    StringUtils::camelCase($entityType) . " #{$item[$field]}"
-                );
+                // qs-03 (mutual-exclusion audience rule): a bucketed_into_experience_key
+                // rule resolves against SDK-stored visitor bucketing state instead of
+                // $visitorProperties. It is resolved read-only here (getEntity() +
+                // getData(), no bucketing/writes/tracking) into a raw boolean, then
+                // routed through the SAME untouched isRuleMatched() generic key/value
+                // dispatch every other rule uses — via a synthetic single-key data/rule
+                // pair whose 'equals' comparison reproduces `matching.negated ? !raw :
+                // raw` using RuleManager's own (unmodified) negation logic
+                // (Comparisons::equals()/returnNegationCheck()). RuleManager itself is
+                // never modified (AC7); any item whose rule tree is NOT a sole
+                // bucketed_into_experience_key rule (every generic key/value rule shape
+                // in production today) is passed through completely unchanged below.
+                $exclusionRule = $visitorId !== null
+                    ? $this->_findSoleBucketedIntoExperienceKeyRule($item['rules'])
+                    : null;
+
+                if ($exclusionRule !== null) {
+                    [$ruleData, $ruleObject] = $this->_buildBucketedIntoExperienceKeyRuleMatch($exclusionRule, $visitorId);
+                    $match = $this->_ruleManager->isRuleMatched(
+                        $ruleData,
+                        $ruleObject,
+                        StringUtils::camelCase($entityType) . " #{$item[$field]}"
+                    );
+                } else {
+                    $match = $this->_ruleManager->isRuleMatched(
+                        $visitorProperties,
+                        new RuleObject($item['rules']),
+                        StringUtils::camelCase($entityType) . " #{$item[$field]}"
+                    );
+                }
 
                 if ($match === true) {
                     $matchedRecords[] = $item;
@@ -1400,6 +1446,120 @@ final class DataManager implements DataManagerInterface
         );
 
         return $matchedRecords;
+    }
+
+    /**
+     * qs-03: whether any of the given (already-fetched) audiences carries a
+     * bucketed_into_experience_key rule as its sole rule. Used to widen the
+     * DataManager.php empty-visitorProperties audience-evaluation gate SOLELY
+     * for experiences whose audience tree needs this rule type (AC4), while
+     * leaving the gate untouched for every generic-only audience (AC7).
+     *
+     * @param array<int, array<string, mixed>> $audiences
+     */
+    private function _audiencesContainBucketedIntoExperienceKeyRule(array $audiences): bool
+    {
+        foreach ($audiences as $audience) {
+            if (!empty($audience['rules']) && $this->_findSoleBucketedIntoExperienceKeyRule($audience['rules']) !== null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * qs-03: returns the rule element if $rulesTree contains EXACTLY ONE
+     * rule element in total and it is a bucketed_into_experience_key rule;
+     * otherwise null (including for mixed generic+exclusion trees, which are
+     * out of scope per qs-03-mutual-exclusion-rule.md's non-goals — no served
+     * config can yet emit one). Returning null routes the item through the
+     * untouched, generic isRuleMatched() path unchanged.
+     *
+     * @param array<string, mixed> $rulesTree The OR/AND/OR_WHEN rule tree
+     * @return array{rule_type: string, matching: array{match_type: string, negated: bool}, value: mixed}|null
+     */
+    private function _findSoleBucketedIntoExperienceKeyRule(array $rulesTree): ?array
+    {
+        $elements = $this->_collectRuleElements($rulesTree);
+        if (count($elements) === 1 && ($elements[0]['rule_type'] ?? null) === RuleType::BucketedIntoExperienceKey->value) {
+            return $elements[0];
+        }
+        return null;
+    }
+
+    /**
+     * qs-03: recursively collects every leaf rule element (identified by the
+     * presence of a `rule_type` key) anywhere within an OR/AND/OR_WHEN rule
+     * tree, regardless of nesting depth or shape.
+     *
+     * @param mixed $node
+     * @return array<int, array<string, mixed>>
+     */
+    private function _collectRuleElements(mixed $node): array
+    {
+        if (!is_array($node)) {
+            return [];
+        }
+        if (isset($node['rule_type'])) {
+            return [$node];
+        }
+        $elements = [];
+        foreach ($node as $value) {
+            if (is_array($value)) {
+                $elements = array_merge($elements, $this->_collectRuleElements($value));
+            }
+        }
+        return $elements;
+    }
+
+    /**
+     * qs-03: resolves a bucketed_into_experience_key rule element read-only
+     * (target lookup via getEntity(), presence check via getData() — never
+     * triggers bucketing of the target, never writes, never tracks — AC5),
+     * then builds a synthetic single-key $data/RuleObject pair that reproduces
+     * the contract's `matching.negated ? !bucketedRaw : bucketedRaw` via the
+     * SAME real, unmodified isRuleMatched() -> Comparisons::equals() negation
+     * logic every generic 'equals' rule already uses.
+     *
+     * Unknown target key -> bucketedRaw = false + AC8 warning naming the key.
+     *
+     * @param array{rule_type: string, matching: array{match_type: string, negated: bool}, value: mixed} $rule
+     * @return array{0: array<string, string>, 1: RuleObject}
+     */
+    private function _buildBucketedIntoExperienceKeyRuleMatch(array $rule, string $visitorId): array
+    {
+        $targetKey = (string)($rule['value'] ?? '');
+        $target = $this->getEntity($targetKey, 'experiences');
+
+        if ($target === null) {
+            $this->_loggerManager?->warn(
+                'DataManager.filterMatchedRecordsWithRule()',
+                str_replace('#', $targetKey, ErrorMessages::BUCKETING_EXCLUSION_TARGET_NOT_FOUND)
+            );
+            $bucketedRaw = false;
+        } else {
+            $visitorData = $this->getData($visitorId) ?? [];
+            $bucketingData = $visitorData['bucketing'] ?? [];
+            $bucketedRaw = array_key_exists((string)$target['id'], $bucketingData);
+        }
+
+        $syntheticKey = '__convertSdk_bucketedIntoExperienceKey';
+        $negated = (bool)($rule['matching']['negated'] ?? false);
+        $syntheticData = [$syntheticKey => $bucketedRaw ? 'true' : 'false'];
+        $syntheticRuleObject = new RuleObject([
+            'OR' => [
+                ['AND' => [
+                    ['OR_WHEN' => [[
+                        'rule_type' => RuleType::BucketedIntoExperienceKey->value,
+                        'key' => $syntheticKey,
+                        'matching' => ['match_type' => 'equals', 'negated' => $negated],
+                        'value' => 'true',
+                    ]]],
+                ]],
+            ],
+        ]);
+
+        return [$syntheticData, $syntheticRuleObject];
     }
 
     /**

--- a/packages/Data/src/DataManager.php
+++ b/packages/Data/src/DataManager.php
@@ -1534,7 +1534,7 @@ final class DataManager implements DataManagerInterface
         if ($target === null) {
             $this->_loggerManager?->warn(
                 'DataManager.filterMatchedRecordsWithRule()',
-                str_replace('#', $targetKey, ErrorMessages::BUCKETING_EXCLUSION_TARGET_NOT_FOUND)
+                str_replace('#', $targetKey, Messages::BUCKETING_EXCLUSION_TARGET_NOT_FOUND)
             );
             $bucketedRaw = false;
         } else {

--- a/packages/Data/tests/MutualExclusionCombinationTest.php
+++ b/packages/Data/tests/MutualExclusionCombinationTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConvertSdk\Tests;
+
+require_once __DIR__ . '/MutualExclusionFixture.php';
+require_once __DIR__ . '/Support/MutualExclusionTestSupport.php';
+
+use ConvertSdk\Tests\Support\MutualExclusionAudienceBuilder;
+use ConvertSdk\Tests\Support\MutualExclusionDataManagerFactory;
+use OpenAPI\Client\BucketingAttributes;
+use OpenAPI\Client\IdentityField;
+use OpenAPI\Client\Model\GenericListMatchingOptions;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * qs-03 (mutual-exclusion audience rule) — AC6 (combination semantics).
+ *
+ * "Identical ALL/ANY combination ... semantics as existing rules"
+ * (qs-03-mutual-exclusion-rule.md line 56). Attaches TWO single-rule
+ * audiences to the real exp-b — one generic `generic_key_value` rule, one
+ * negated `bucketed_into_experience_key` rule targeting exp-a — and drives
+ * `experience.settings.matching_options.audiences` (all/any) across a small
+ * table proving the new rule type combines exactly like any other rule via
+ * DataManager::matchRulesByField() (see MutualExclusionRuleResolutionTest
+ * for the full seam signature/contract).
+ *
+ * Unlike the AC1/AC4/AC8 fixture table, this test legitimately supplies
+ * non-empty visitorProperties in some rows to drive the generic rule's
+ * outcome — AC6 is about ALL/ANY combination logic, not the zero-input
+ * property (that is AC4's concern, covered by MutualExclusionRuleResolutionTest).
+ *
+ * Every row asserts the exclusion audience's OWN resolution (via
+ * SpyRuleManager::lastResultForLogEntryContaining()) against its intended
+ * boolean, independently of the ALL/ANY aggregate — this is what forces a
+ * genuine failure on every row today: the exclusion rule currently either
+ * (a) resolves to a fixed `false` fall-through (no `key` field => "unknown
+ * rule_type" path, RuleManager.php's fail-closed default) whenever the
+ * audience block is entered, or (b) is never evaluated at all when
+ * visitorProperties is `[]` (DataManager.php:410 gate). Neither matches this
+ * table's intended values in every row, so relying on the aggregate
+ * `matched` alone would let some rows pass by coincidence.
+ */
+final class MutualExclusionCombinationTest extends TestCase
+{
+    private const GENERIC_KEY = 'plan';
+    private const GENERIC_VALUE = 'enterprise';
+
+    /**
+     * @return array<string, array{0: string, 1: bool, 2: bool, 3: bool}>
+     *   [matchingOption, genericConditionSatisfied, exclusionIntendedMatched, expectedAggregateMatched]
+     */
+    public static function combinations(): array
+    {
+        return [
+            'all_bothPass_matches' => [GenericListMatchingOptions::ALL, true, true, true],
+            'all_genericFails_noMatch' => [GenericListMatchingOptions::ALL, false, true, false],
+            'any_exclusionPasses_matches' => [GenericListMatchingOptions::ANY, false, true, true],
+            'any_bothFail_noMatch' => [GenericListMatchingOptions::ANY, false, false, false],
+        ];
+    }
+
+    #[DataProvider('combinations')]
+    public function testGenericAndExclusionRulesCombinePerMatchingOption(
+        string $matchingOption,
+        bool $genericConditionSatisfied,
+        bool $exclusionIntendedMatched,
+        bool $expectedAggregateMatched
+    ): void {
+        $visitorId = 'mx-combination-visitor';
+        $configData = MutualExclusionAudienceBuilder::withCombinedAudiencesOnExperienceB(
+            MutualExclusionAudienceBuilder::loadBaseConfigData(),
+            $matchingOption,
+            self::GENERIC_KEY,
+            self::GENERIC_VALUE,
+            exclusionNegated: true // matches when visitor is NOT bucketed into exp-a
+        );
+
+        $built = MutualExclusionDataManagerFactory::build($configData);
+        $dataManager = $built['dataManager'];
+        $ruleManager = $built['ruleManager'];
+
+        // exclusionIntendedMatched=false requires bucketedRaw=true (negated flips it to false).
+        if (!$exclusionIntendedMatched) {
+            $dataManager->putData($visitorId, [
+                'bucketing' => [MutualExclusionFixture::EXPERIENCE_A_ID => MutualExclusionFixture::VARIATION_A_ID],
+            ]);
+        }
+
+        $visitorProperties = $genericConditionSatisfied ? [self::GENERIC_KEY => self::GENERIC_VALUE] : [];
+
+        $result = $dataManager->matchRulesByField(
+            $visitorId,
+            MutualExclusionFixture::EXPERIENCE_B_KEY,
+            IdentityField::KEY,
+            new BucketingAttributes([
+                'visitorProperties' => $visitorProperties,
+                'ignoreLocationProperties' => true,
+            ])
+        );
+
+        self::assertSame(
+            $exclusionIntendedMatched,
+            $ruleManager->lastResultForLogEntryContaining(MutualExclusionAudienceBuilder::EXCLUSION_AUDIENCE_KEY),
+            'The exclusion audience must itself resolve to its intended boolean, independent of the ALL/ANY aggregate.'
+        );
+
+        self::assertSame(
+            $expectedAggregateMatched,
+            $result !== null,
+            sprintf(
+                'matching_options.audiences=%s, generic=%s, exclusionIntended=%s: expected matched=%s, got %s',
+                $matchingOption,
+                $genericConditionSatisfied ? 'pass' : 'fail',
+                $exclusionIntendedMatched ? 'true' : 'false',
+                $expectedAggregateMatched ? 'true' : 'false',
+                $result === null ? 'null' : 'non-null'
+            )
+        );
+    }
+}

--- a/packages/Data/tests/MutualExclusionFixture.php
+++ b/packages/Data/tests/MutualExclusionFixture.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConvertSdk\Tests;
+
+/**
+ * qs-03 (mutual-exclusion audience rule, `bucketed_into_experience_key`) — the
+ * single hoisted, contract-exact 8-row fixture table from
+ * `qs-03-mutual-exclusion-rule.md` lines 66-77. Expected values ARE the
+ * contract; never recompute or "improve" them independently of the spec.
+ *
+ * Pairs with `mutual-exclusion-config.json` in this directory, which defines
+ * the two experiences the fixture targets:
+ *   - exp-a: id "100111", variation "100901" (a/b_fullstack, active)
+ *   - exp-b: id "100222", variation "100902" (a/b_fullstack, active)
+ * "exp-zz" (rows 6/7) is deliberately absent from that config — it is the
+ * unknown-target case (AC8).
+ *
+ * NOT PSR-4/classmap autoloadable: the root composer.json maps `ConvertSdk\Tests\`
+ * only to `packages/Utils/tests/` (composer.json:52), and this file's name does
+ * not match PHPUnit's `*Test.php` directory-collector pattern. Any consumer —
+ * in this package or another — MUST `require_once` this file's absolute path
+ * before referencing the class (see `MutualExclusionFixtureTest.php` in this
+ * same directory for the in-package pattern). Once loaded, consume rows via
+ * PHPUnit's `#[DataProviderExternal(MutualExclusionFixture::class, 'rows')]`
+ * attribute (PHPUnit 11).
+ */
+final class MutualExclusionFixture
+{
+    public const EXPERIENCE_A_KEY = 'exp-a';
+    public const EXPERIENCE_A_ID = '100111';
+    public const VARIATION_A_ID = '100901';
+
+    public const EXPERIENCE_B_KEY = 'exp-b';
+    public const EXPERIENCE_B_ID = '100222';
+    public const VARIATION_B_ID = '100902';
+
+    /** Target key that does not exist in mutual-exclusion-config.json (AC8). */
+    public const UNKNOWN_EXPERIENCE_KEY = 'exp-zz';
+
+    /**
+     * Row shape (positional, matches spec table columns 1:1 plus two derived
+     * flags):
+     *
+     *   0 => bucketingMap    array  What getData($visitorId)['bucketing'] must
+     *                               resolve to (merged in-memory + store) at
+     *                               evaluation time. Keyed by (string) target
+     *                               experience id, per DataManager's stored
+     *                               bucketing-map shape.
+     *   1 => ruleValue       string The `bucketed_into_experience_key` rule's
+     *                               `value` (a target experience KEY, not id).
+     *   2 => negated         bool   `matching.negated` on the rule.
+     *   3 => expectedMatched bool   The contract's expected `matched` result.
+     *   4 => expectsWarning  bool   true only for rows 6/7 (AC8) — the
+     *                               unknown-target-key warning must fire,
+     *                               naming `ruleValue`.
+     *   5 => storeOnly       bool   true only for row 8 (AC3) — the fixture's
+     *                               bucketingMap MUST be placed exclusively in
+     *                               the persistent DataStore/cache, never in
+     *                               the in-memory bucketing map, to prove
+     *                               cross-request attribution. false for every
+     *                               other row means "in-memory is sufficient"
+     *                               — it does not forbid also exercising a
+     *                               persistent store for those rows.
+     *
+     * @return array<string, array{0: array<string, string>, 1: string, 2: bool, 3: bool, 4: bool, 5: bool}>
+     */
+    public static function rows(): array
+    {
+        return [
+            'row1_emptyMap_notNegated_expA' => [
+                [],
+                self::EXPERIENCE_A_KEY,
+                false,
+                false,
+                false,
+                false,
+            ],
+            'row2_emptyMap_negated_expA' => [
+                [],
+                self::EXPERIENCE_A_KEY,
+                true,
+                true,
+                false,
+                false,
+            ],
+            'row3_bucketedIntoA_notNegated_expA' => [
+                [self::EXPERIENCE_A_ID => self::VARIATION_A_ID],
+                self::EXPERIENCE_A_KEY,
+                false,
+                true,
+                false,
+                false,
+            ],
+            'row4_bucketedIntoA_negated_expA' => [
+                [self::EXPERIENCE_A_ID => self::VARIATION_A_ID],
+                self::EXPERIENCE_A_KEY,
+                true,
+                false,
+                false,
+                false,
+            ],
+            'row5_bucketedIntoB_negated_expA' => [
+                [self::EXPERIENCE_B_ID => self::VARIATION_B_ID],
+                self::EXPERIENCE_A_KEY,
+                true,
+                true,
+                false,
+                false,
+            ],
+            'row6_unknownTarget_notNegated' => [
+                [],
+                self::UNKNOWN_EXPERIENCE_KEY,
+                false,
+                false,
+                true,
+                false,
+            ],
+            'row7_unknownTarget_negated' => [
+                [],
+                self::UNKNOWN_EXPERIENCE_KEY,
+                true,
+                true,
+                true,
+                false,
+            ],
+            'row8_storeOnlyBucketing_negated_expA' => [
+                [self::EXPERIENCE_A_ID => self::VARIATION_A_ID],
+                self::EXPERIENCE_A_KEY,
+                true,
+                false,
+                false,
+                true,
+            ],
+        ];
+    }
+}

--- a/packages/Data/tests/MutualExclusionFixtureTest.php
+++ b/packages/Data/tests/MutualExclusionFixtureTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConvertSdk\Tests;
+
+// MutualExclusionFixture.php is NOT reachable via Composer's PSR-4 autoload:
+// the root composer.json maps `ConvertSdk\Tests\` only to `packages/Utils/tests/`
+// (see composer.json:52 / vendor/composer/autoload_psr4.php), and PHPUnit's
+// directory-based test collector only `require`s files matching `*Test.php`.
+// A plain-named fixture class in this directory must be pulled in explicitly.
+require_once __DIR__ . '/MutualExclusionFixture.php';
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the qs-03 mutual-exclusion fixture itself (MutualExclusionFixture::rows())
+ * against accidental drift from the contract table in
+ * `qs-03-mutual-exclusion-rule.md` lines 66-77 — the fixture's expected values
+ * ARE the contract, so this locks its shape/cardinality, not its semantics
+ * (semantics are exercised by PHP-3's RuleManager/DataManager-facing tests).
+ */
+final class MutualExclusionFixtureTest extends TestCase
+{
+    public function testFixtureHasExactlyEightRows(): void
+    {
+        $this->assertCount(8, MutualExclusionFixture::rows());
+    }
+
+    public function testFixtureRowKeysAreUniqueAndDescriptive(): void
+    {
+        $keys = array_keys(MutualExclusionFixture::rows());
+        $this->assertSame(array_unique($keys), $keys, 'Row keys must be unique dataset names');
+        foreach ($keys as $key) {
+            $this->assertMatchesRegularExpression('/^row[1-8]_/', $key);
+        }
+    }
+
+    public function testEachRowHasTheContractShape(): void
+    {
+        foreach (MutualExclusionFixture::rows() as $name => $row) {
+            $this->assertCount(6, $row, "Row '$name' must have exactly 6 columns");
+            [$bucketingMap, $ruleValue, $negated, $expectedMatched, $expectsWarning, $storeOnly] = $row;
+            $this->assertIsArray($bucketingMap, "Row '$name' bucketingMap must be an array");
+            $this->assertIsString($ruleValue, "Row '$name' ruleValue must be a string");
+            $this->assertIsBool($negated, "Row '$name' negated must be a bool");
+            $this->assertIsBool($expectedMatched, "Row '$name' expectedMatched must be a bool");
+            $this->assertIsBool($expectsWarning, "Row '$name' expectsWarning must be a bool");
+            $this->assertIsBool($storeOnly, "Row '$name' storeOnly must be a bool");
+        }
+    }
+
+    public function testOnlyRowsSixAndSevenExpectAWarning(): void
+    {
+        $warnRows = array_keys(array_filter(
+            MutualExclusionFixture::rows(),
+            fn (array $row): bool => $row[4] === true
+        ));
+
+        $this->assertSame(
+            ['row6_unknownTarget_notNegated', 'row7_unknownTarget_negated'],
+            $warnRows,
+            'AC8: only the unknown-target rows (6/7) expect a warning'
+        );
+    }
+
+    public function testOnlyRowEightIsStoreOnly(): void
+    {
+        $storeOnlyRows = array_keys(array_filter(
+            MutualExclusionFixture::rows(),
+            fn (array $row): bool => $row[5] === true
+        ));
+
+        $this->assertSame(
+            ['row8_storeOnlyBucketing_negated_expA'],
+            $storeOnlyRows,
+            'AC3: only row 8 requires persistent-store-only placement'
+        );
+    }
+
+    public function testRowsSixAndSevenTargetAKeyAbsentFromTheFixtureConfig(): void
+    {
+        $config = json_decode(
+            (string) file_get_contents(__DIR__ . '/mutual-exclusion-config.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $experienceKeys = array_column($config['data']['experiences'], 'key');
+
+        $this->assertNotContains(MutualExclusionFixture::UNKNOWN_EXPERIENCE_KEY, $experienceKeys);
+        $this->assertContains(MutualExclusionFixture::EXPERIENCE_A_KEY, $experienceKeys);
+        $this->assertContains(MutualExclusionFixture::EXPERIENCE_B_KEY, $experienceKeys);
+    }
+}

--- a/packages/Data/tests/MutualExclusionGenericRegressionTest.php
+++ b/packages/Data/tests/MutualExclusionGenericRegressionTest.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConvertSdk\Tests;
+
+require_once __DIR__ . '/Support/MutualExclusionTestSupport.php';
+
+use ConvertSdk\Tests\Support\MutualExclusionAudienceBuilder;
+use ConvertSdk\Tests\Support\MutualExclusionDataManagerFactory;
+use OpenAPI\Client\BucketingAttributes;
+use OpenAPI\Client\IdentityField;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * qs-03 (mutual-exclusion audience rule, `bucketed_into_experience_key`) —
+ * PHP-4, AC7 (generic-rule regression lock): "The 3 generic key/value rule
+ * types behave bit-identically to today (full suite green + targeted
+ * regression vectors if the resolution seam changed their path)."
+ * (qs-03-mutual-exclusion-rule.md line 87.)
+ *
+ * The "3 generic key/value rule types" are the real served `rule_type`
+ * literals defined by the generated OpenAPI models
+ * packages/Types/lib/Generated/Model/Generic{Text,Numeric,Bool}KeyValueMatchRulesTypes.php:
+ * `generic_text_key_value`, `generic_numeric_key_value`, `generic_bool_key_value`.
+ * All three (plus a realistic mixed-shape example) already appear together in
+ * production-shaped fixture data at tests/Integration/static-config.json's
+ * "adv-audience"/"dasadsa" location entries — this suite mirrors those exact
+ * (key, match_type, value-type) combinations rather than inventing new ones.
+ *
+ * The qs-03 PHP-3 seam under regression lock here is
+ * DataManager::filterMatchedRecordsWithRule()'s new sole-rule collector
+ * (`_findSoleBucketedIntoExperienceKeyRule()` / `_collectRuleElements()`,
+ * introduced to route a SOLE `bucketed_into_experience_key` rule through a
+ * synthetic single-key isRuleMatched() delegation — see
+ * DataManager.php:1401-1449) and DataManager::matchRulesByField()'s widened
+ * empty-visitorProperties gate (DataManager.php:407-425). Every rule tree in
+ * this suite is generic-only (zero bucketed_into_experience_key elements), so
+ * the collector must be on the call stack (whenever $visitorId is passed) but
+ * ALWAYS take the else-branch — the original, unmodified
+ * `isRuleMatched($visitorProperties, new RuleObject($item['rules']), ...)`
+ * call that existed before PHP-3.
+ *
+ * ADDITIONAL to, not a replacement for, the pre-existing regression vector
+ * tests/Integration/FullChainIntegrationTest.php::
+ * testRunExperienceWithAudienceAndNoVisitorPropertiesReturnsNull (unmodified,
+ * confirmed still green by PHP-3's own verification).
+ */
+final class MutualExclusionGenericRegressionTest extends TestCase
+{
+    /**
+     * Item 1: generic key/value rules match identically through
+     * DataManager::filterMatchedRecordsWithRule(), across the 3 real generic
+     * rule_type literals, covering:
+     *   (a) a matching case
+     *   (b) a non-matching case
+     *   (c) $visitorId explicitly passed (puts the sole-rule collector on the
+     *       call stack)
+     *   (d) $visitorId null/omitted (collector short-circuits without even
+     *       being invoked — see DataManager.php:1413)
+     * In every row the new $visitorId parameter must not alter the generic
+     * matching outcome in either direction.
+     *
+     * @return array<string, array{0: string, 1: string, 2: string, 3: mixed, 4: array<string, mixed>, 5: ?string, 6: bool}>
+     */
+    public static function genericRuleVectors(): array
+    {
+        return [
+            // generic_text_key_value — mirrors static-config.json's "browser"
+            // audience rule shape (string key/value, 'equals'-family comparator).
+            'text_matches_visitorIdPassed' => [
+                'generic_text_key_value', 'browser', 'equals', 'chrome',
+                ['browser' => 'chrome'], 'mx-generic-visitor-1', true,
+            ],
+            'text_notMatches_visitorIdPassed' => [
+                'generic_text_key_value', 'browser', 'equals', 'chrome',
+                ['browser' => 'firefox'], 'mx-generic-visitor-1', false,
+            ],
+            // generic_numeric_key_value — mirrors static-config.json's "feature"
+            // location rule shape (numeric key/value, 'less' comparator).
+            'numeric_matches_visitorIdNull' => [
+                'generic_numeric_key_value', 'feature', 'less', 5,
+                ['feature' => 3], null, true,
+            ],
+            'numeric_notMatches_visitorIdNull' => [
+                'generic_numeric_key_value', 'feature', 'less', 5,
+                ['feature' => 9], null, false,
+            ],
+            // generic_bool_key_value — mirrors static-config.json's "desktop"
+            // audience rule shape (real PHP bool key/value, 'equals' comparator).
+            'bool_matches_visitorIdPassed' => [
+                'generic_bool_key_value', 'desktop', 'equals', true,
+                ['desktop' => true], 'mx-generic-visitor-2', true,
+            ],
+            'bool_notMatches_visitorIdOmitted' => [
+                'generic_bool_key_value', 'desktop', 'equals', true,
+                ['desktop' => false], null, false,
+            ],
+        ];
+    }
+
+    #[DataProvider('genericRuleVectors')]
+    public function testGenericRuleTypeMatchesIdenticallyRegardlessOfVisitorIdParam(
+        string $ruleType,
+        string $key,
+        string $matchType,
+        mixed $ruleValue,
+        array $visitorProperties,
+        ?string $visitorId,
+        bool $expectedMatched
+    ): void {
+        $item = self::singleRuleItem($ruleType, $key, $matchType, $ruleValue, negated: false);
+
+        $built = MutualExclusionDataManagerFactory::build(MutualExclusionAudienceBuilder::loadBaseConfigData());
+        $dataManager = $built['dataManager'];
+        $ruleManager = $built['ruleManager'];
+
+        $matched = $visitorId !== null
+            ? $dataManager->filterMatchedRecordsWithRule([$item], $visitorProperties, 'audience', IdentityField::KEY, $visitorId)
+            : $dataManager->filterMatchedRecordsWithRule([$item], $visitorProperties, 'audience', IdentityField::KEY);
+
+        self::assertSame(
+            $expectedMatched,
+            $matched === [$item],
+            sprintf(
+                'Expected %s rule (%s %s %s) against visitorProperties=%s (visitorId=%s) to resolve matched=%s',
+                $ruleType,
+                $key,
+                $matchType,
+                var_export($ruleValue, true),
+                json_encode($visitorProperties),
+                $visitorId ?? 'null',
+                $expectedMatched ? 'true' : 'false'
+            )
+        );
+
+        self::assertCount(
+            1,
+            $ruleManager->calls,
+            'A single-item, single-rule-element generic tree must invoke isRuleMatched() exactly once.'
+        );
+        self::assertSame(
+            $visitorProperties,
+            $ruleManager->calls[0]['data'],
+            'A generic-only rule tree must route through isRuleMatched() with the ORIGINAL $visitorProperties '
+                . 'unchanged — never the qs-03 synthetic single-key data pair — proving the else-branch (the '
+                . 'original, untouched generic dispatch path) was taken regardless of whether $visitorId was passed.'
+        );
+    }
+
+    /**
+     * Item 2 — the critical AC7 counterpart to AC4: an experience whose ONLY
+     * audience carries a generic rule (zero bucketed_into_experience_key
+     * elements anywhere in its tree), evaluated with visitorProperties=[],
+     * must still resolve to null/not-matched. DataManager.php:419's
+     * `$hasBucketingExclusionAudience` must compute false here, so the widened
+     * gate (`$visitorProperties || $hasBucketingExclusionAudience`,
+     * DataManager.php:425) behaves EXACTLY as the pre-qs-03
+     * `if ($visitorProperties)` gate did — audience evaluation must not even
+     * be entered.
+     */
+    public function testGenericOnlyAudienceWithEmptyVisitorPropertiesStaysExcluded(): void
+    {
+        $configData = MutualExclusionAudienceBuilder::withGenericOnlyUnderTestExperience(
+            MutualExclusionAudienceBuilder::loadBaseConfigData(),
+            'plan',
+            'enterprise'
+        );
+
+        $built = MutualExclusionDataManagerFactory::build($configData);
+        $dataManager = $built['dataManager'];
+        $ruleManager = $built['ruleManager'];
+
+        $result = $dataManager->matchRulesByField(
+            'mx-generic-only-empty-props-visitor',
+            MutualExclusionAudienceBuilder::UNDER_TEST_EXPERIENCE_KEY,
+            IdentityField::KEY,
+            new BucketingAttributes([
+                'visitorProperties' => [],
+                'ignoreLocationProperties' => true,
+            ])
+        );
+
+        self::assertNull(
+            $result,
+            'A generic-only audience with empty visitorProperties must still resolve to null — the qs-03 gate '
+                . 'widening is scoped strictly to bucketed_into_experience_key audiences (AC7).'
+        );
+
+        self::assertSame(
+            0,
+            $ruleManager->isRuleMatchedCallCount,
+            'isRuleMatched() must never be invoked for a generic-only audience when visitorProperties is empty — '
+                . 'the :410-area gate must skip audience evaluation entirely, exactly as before qs-03.'
+        );
+    }
+
+    /**
+     * Item 3: a rule tree containing MORE THAN ONE rule element (two generic
+     * rules combined under a single AND group) is never mistaken for a "sole
+     * exclusion rule" — _findSoleBucketedIntoExperienceKeyRule()'s "exactly
+     * one element total" guard (DataManager.php:1481-1488) falls through to
+     * the untouched generic AND-walk dispatch regardless of element count.
+     * Mirrors static-config.json's "homescreen" location rule shape (two
+     * generic_text_key_value elements ANDed together).
+     *
+     * Constructing a real mixed generic+exclusion tree is out of scope per
+     * qs-03's non-goals (no served config can yet emit one — see
+     * qs-03-mutual-exclusion-rule.md Non-goals, and PHP-3's decision-log
+     * "Assume a single bucketed_into_experience_key rule per exclusion
+     * audience tree" entry); two generic rules is the documented acceptable
+     * substitute, since it already exercises the ">1 element => not sole"
+     * guard using existing generic rule types.
+     *
+     * @return array<string, array{0: array<string, mixed>, 1: bool}>
+     */
+    public static function twoElementVectors(): array
+    {
+        return [
+            'bothMatch_andSatisfied' => [
+                ['browser' => 'chrome', 'country' => 'US'], true,
+            ],
+            'oneMismatches_andFails' => [
+                ['browser' => 'chrome', 'country' => 'DE'], false,
+            ],
+        ];
+    }
+
+    #[DataProvider('twoElementVectors')]
+    public function testMultiElementGenericTreeNeverMistakenForSoleExclusionRule(
+        array $visitorProperties,
+        bool $expectedMatched
+    ): void {
+        $item = [
+            'id' => 'multi-element-item',
+            'key' => 'multi-element-item',
+            'rules' => [
+                'OR' => [
+                    ['AND' => [
+                        ['OR_WHEN' => [[
+                            'rule_type' => 'generic_text_key_value',
+                            'matching' => ['match_type' => 'equals', 'negated' => false],
+                            'value' => 'chrome',
+                            'key' => 'browser',
+                        ]]],
+                        ['OR_WHEN' => [[
+                            'rule_type' => 'generic_text_key_value',
+                            'matching' => ['match_type' => 'equals', 'negated' => false],
+                            'value' => 'US',
+                            'key' => 'country',
+                        ]]],
+                    ]],
+                ],
+            ],
+        ];
+
+        $built = MutualExclusionDataManagerFactory::build(MutualExclusionAudienceBuilder::loadBaseConfigData());
+        $dataManager = $built['dataManager'];
+        $ruleManager = $built['ruleManager'];
+
+        $matched = $dataManager->filterMatchedRecordsWithRule(
+            [$item],
+            $visitorProperties,
+            'audience',
+            IdentityField::KEY,
+            'mx-multi-element-visitor'
+        );
+
+        self::assertSame($expectedMatched, $matched === [$item]);
+
+        self::assertCount(
+            1,
+            $ruleManager->calls,
+            'A single item still results in exactly ONE top-level isRuleMatched() call, regardless of how many '
+                . 'rule elements its tree contains — the AND walk happens inside the real, unmodified RuleManager.'
+        );
+        self::assertSame(
+            $visitorProperties,
+            $ruleManager->calls[0]['data'],
+            'A >1-rule-element tree must route through isRuleMatched() with the ORIGINAL $visitorProperties — '
+                . 'proving the sole-exclusion-rule guard correctly excludes multi-element trees from synthetic '
+                . 'delegation, even though $visitorId was passed.'
+        );
+    }
+
+    /**
+     * Builds a single-rule-element OR/AND/OR_WHEN tree item, matching the
+     * shape MutualExclusionAudienceBuilder::genericRuleElement() uses but
+     * parameterized by rule_type/match_type/value-type so this single helper
+     * covers all 3 generic rule_type literals under test (avoids copy-pasting
+     * the tree shape per data-provider row — see
+     * .claude/rules/sonarqube-new-code-duplication.md).
+     *
+     * @param mixed $ruleValue
+     * @return array<string, mixed>
+     */
+    private static function singleRuleItem(string $ruleType, string $key, string $matchType, mixed $ruleValue, bool $negated): array
+    {
+        return [
+            'id' => 'generic-item-under-test',
+            'key' => 'generic-item-under-test',
+            'rules' => [
+                'OR' => [
+                    ['AND' => [
+                        ['OR_WHEN' => [[
+                            'rule_type' => $ruleType,
+                            'matching' => ['match_type' => $matchType, 'negated' => $negated],
+                            'value' => $ruleValue,
+                            'key' => $key,
+                        ]]],
+                    ]],
+                ],
+            ],
+        ];
+    }
+}

--- a/packages/Data/tests/MutualExclusionReadOnlyTest.php
+++ b/packages/Data/tests/MutualExclusionReadOnlyTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConvertSdk\Tests;
+
+require_once __DIR__ . '/MutualExclusionFixture.php';
+require_once __DIR__ . '/Support/MutualExclusionTestSupport.php';
+
+use ConvertSdk\Tests\Support\MutualExclusionAudienceBuilder;
+use ConvertSdk\Tests\Support\MutualExclusionDataManagerFactory;
+use ConvertSdk\Tests\Support\MutualExclusionDataStoreDouble;
+use OpenAPI\Client\BucketingAttributes;
+use OpenAPI\Client\IdentityField;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * qs-03 (mutual-exclusion audience rule) — AC5 (read-only).
+ *
+ * Contract (qs-03-mutual-exclusion-rule.md line 53): "The check is read-only:
+ * never triggers bucketing of the target, never writes, never tracks."
+ *
+ * Exercises DataManager::matchRulesByField() (see MutualExclusionRuleResolutionTest
+ * for the full seam signature/contract) directly, in isolation from the wider
+ * bucketing pipeline, so a passing implementation can't hide a read-only
+ * violation behind other legitimate writes an experience decision would make.
+ * The visitor is NOT bucketed into the target (exp-a) at evaluation time —
+ * proving the exclusion CHECK itself never buckets exp-a to find out whether
+ * it applies.
+ */
+final class MutualExclusionReadOnlyTest extends TestCase
+{
+    public function testEvaluatingExclusionRuleTriggersNoBucketingWriteOrTracking(): void
+    {
+        $visitorId = 'mx-readonly-visitor';
+        $configData = MutualExclusionAudienceBuilder::withUnderTestExperience(
+            MutualExclusionAudienceBuilder::loadBaseConfigData(),
+            MutualExclusionFixture::EXPERIENCE_A_KEY,
+            true // negated: true — matches when visitor is NOT bucketed into exp-a
+        );
+
+        $storeDouble = new MutualExclusionDataStoreDouble();
+        $built = MutualExclusionDataManagerFactory::build($configData, ['dataStore' => $storeDouble]);
+        $dataManager = $built['dataManager'];
+        $bucketingManager = $built['bucketingManager'];
+        $apiManager = $built['apiManager'];
+
+        // Sanity: visitor has no stored bucketing decision anywhere yet. Note:
+        // with a persistent store wired, getData() always merges to at least
+        // `[]` (never null — ObjectUtils::objectDeepMerge() of two empty
+        // arrays), so the sanity check targets the 'bucketing' sub-key.
+        self::assertSame([], $dataManager->getData($visitorId)['bucketing'] ?? [], 'Visitor must start unbucketed everywhere.');
+
+        $result = $dataManager->matchRulesByField(
+            $visitorId,
+            MutualExclusionAudienceBuilder::UNDER_TEST_EXPERIENCE_KEY,
+            IdentityField::KEY,
+            new BucketingAttributes([
+                'visitorProperties' => [],
+                'ignoreLocationProperties' => true,
+            ])
+        );
+
+        // AC1/row2 shape: negated + not-bucketed => matched. Asserted here too
+        // so a future "false negative" implementation (e.g. one that silently
+        // buckets the target to force a result) can't slip through unnoticed
+        // even though this file's focus is the read-only spies below.
+        self::assertNotNull($result, 'Sanity: exclusion rule should resolve matched=true (negated, not bucketed).');
+
+        // matchRulesByField() never buckets ANYTHING itself (bucketing only
+        // happens downstream in _getBucketingByField()/_retrieveBucketing(),
+        // which this test never calls) — so ANY recorded bucketing call at
+        // all, for exp-a or exp-under-test, is already a read-only violation.
+        self::assertSame(
+            [],
+            $bucketingManager->bucketedExperienceIds,
+            'Evaluating the exclusion rule must never bucket its target experience (exp-a).'
+        );
+
+        self::assertSame(
+            [],
+            $storeDouble->setCalls,
+            'Evaluating the exclusion rule must never write to the persistent store.'
+        );
+
+        self::assertSame(
+            [],
+            $apiManager->enqueuedVisitorIds,
+            'Evaluating the exclusion rule must never enqueue a tracking event.'
+        );
+    }
+}

--- a/packages/Data/tests/MutualExclusionRuleResolutionTest.php
+++ b/packages/Data/tests/MutualExclusionRuleResolutionTest.php
@@ -122,7 +122,7 @@ final class MutualExclusionRuleResolutionTest extends TestCase
                 $logManager->hasWarnContaining($ruleValue),
                 sprintf(
                     'Expected a warn log naming unresolved target key "%s" '
-                        . '(ErrorMessages::BUCKETING_EXCLUSION_TARGET_NOT_FOUND, AC8).',
+                        . '(Messages::BUCKETING_EXCLUSION_TARGET_NOT_FOUND, AC8).',
                     $ruleValue
                 )
             );

--- a/packages/Data/tests/MutualExclusionRuleResolutionTest.php
+++ b/packages/Data/tests/MutualExclusionRuleResolutionTest.php
@@ -128,4 +128,61 @@ final class MutualExclusionRuleResolutionTest extends TestCase
             );
         }
     }
+
+    /**
+     * Regression test (Gemini review R1, post-qs-03 merge): mirrors fixture
+     * row 4 (bucketed into exp-a, negated exclusion rule targeting exp-a,
+     * expectedMatched=false) but constructs BucketingAttributes WITHOUT ever
+     * setting visitorProperties, so the internal field is genuinely `null`
+     * (every other row/test in this file uses `[]`). This is a real,
+     * previously-untested caller path: the qs-03 gate widening at
+     * DataManager.php:425 (`if ($visitorProperties || $hasBucketingExclusionAudience)`)
+     * lets execution reach filterMatchedRecordsWithRule() even when
+     * $visitorProperties is null, and that call site used to forward
+     * $visitorProperties as-is into filterMatchedRecordsWithRule()'s
+     * non-nullable `array $visitorProperties` parameter — a reachable
+     * TypeError. Asserts both that no TypeError is thrown AND that the
+     * negated-exclusion outcome is correct (mirrors row 4's expectedMatched).
+     */
+    public function testNullVisitorPropertiesDoesNotThrowOnNegatedExclusion(): void
+    {
+        $visitorId = 'mx-null-visitor-properties';
+        $configData = MutualExclusionAudienceBuilder::withUnderTestExperience(
+            MutualExclusionAudienceBuilder::loadBaseConfigData(),
+            MutualExclusionFixture::EXPERIENCE_A_KEY,
+            true
+        );
+
+        $built = MutualExclusionDataManagerFactory::build($configData);
+        $dataManager = $built['dataManager'];
+        $ruleManager = $built['ruleManager'];
+
+        $dataManager->putData($visitorId, ['bucketing' => [
+            MutualExclusionFixture::EXPERIENCE_A_ID => MutualExclusionFixture::VARIATION_A_ID,
+        ]]);
+
+        $result = $dataManager->matchRulesByField(
+            $visitorId,
+            MutualExclusionAudienceBuilder::UNDER_TEST_EXPERIENCE_KEY,
+            IdentityField::KEY,
+            new BucketingAttributes([
+                'ignoreLocationProperties' => true,
+                // visitorProperties intentionally omitted -> genuinely null,
+                // not [] -- reproduces the previously-untested caller path.
+            ])
+        );
+
+        self::assertNull(
+            $result,
+            'Visitor already bucketed into exp-a must be excluded by the negated rule '
+                . '(matches fixture row 4) even when visitorProperties was never set (null, not []).'
+        );
+
+        self::assertGreaterThan(
+            0,
+            $ruleManager->isRuleMatchedCallCount,
+            'RuleManager::isRuleMatched() must be invoked even with null visitorProperties '
+                . 'once the audience carries a bucketed_into_experience_key rule.'
+        );
+    }
 }

--- a/packages/Data/tests/MutualExclusionRuleResolutionTest.php
+++ b/packages/Data/tests/MutualExclusionRuleResolutionTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConvertSdk\Tests;
+
+require_once __DIR__ . '/MutualExclusionFixture.php';
+require_once __DIR__ . '/Support/MutualExclusionTestSupport.php';
+
+use ConvertSdk\Tests\Support\MutualExclusionAudienceBuilder;
+use ConvertSdk\Tests\Support\MutualExclusionDataManagerFactory;
+use ConvertSdk\Tests\Support\MutualExclusionDataStoreDouble;
+use OpenAPI\Client\BucketingAttributes;
+use OpenAPI\Client\IdentityField;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * qs-03 (mutual-exclusion audience rule, `bucketed_into_experience_key`) —
+ * AC1 (fixture), AC4 (zero new inputs), AC8 (unknown-target warning).
+ *
+ * Seam pinned for Phase 2 (qs-03-mutual-exclusion-rule.md lines 44-56):
+ *
+ *   DataManager::matchRulesByField(
+ *       string $visitorId,
+ *       string $identity,
+ *       string $identityField,
+ *       \OpenAPI\Client\BucketingAttributes $attributes
+ *   ): array|\ConvertSdk\Enums\RuleError|null
+ *
+ * Resolution algorithm under test:
+ *   target      = DataManager::getEntity($rule['value'], 'experiences')  (null on miss)
+ *   bucketedRaw = target exists AND getData($visitorId)['bucketing'] has an
+ *                 entry keyed (string) target['id']
+ *   matched     = matching.negated ? !bucketedRaw : bucketedRaw
+ *
+ * Each fixture row attaches the rule as the SOLE audience on a synthetic
+ * "exp-under-test" experience (MutualExclusionAudienceBuilder::
+ * withUnderTestExperience()) isolated from exp-a/exp-b, so
+ * matchRulesByField()'s non-null/null return is a direct proxy for the
+ * audience's (i.e. this one rule's) `matched` boolean.
+ *
+ * AC4 trap this test is designed to catch: visitorProperties is `[]` for
+ * every row. PHP's `[]` is falsy, so DataManager.php:410
+ * (`if ($visitorProperties) { ...evaluate audience... }`) currently skips
+ * audience evaluation entirely whenever properties are empty — regardless of
+ * the audience's rule content. That means today EVERY row resolves to
+ * `null` (not-matched), which would let the 4 `expectedMatched === false`
+ * rows pass "by accident" without any real implementation. To force a
+ * genuine failure on every row, this test additionally asserts
+ * RuleManager::isRuleMatched() was actually invoked (via SpyRuleManager) —
+ * proving the audience block was genuinely entered, not gate-skipped. That
+ * assertion fails for all 8 rows today; Phase 2 must widen the line-410 gate
+ * so an audience carrying a `bucketed_into_experience_key` rule is evaluated
+ * even with `[]` properties.
+ */
+final class MutualExclusionRuleResolutionTest extends TestCase
+{
+    #[DataProviderExternal(MutualExclusionFixture::class, 'rows')]
+    public function testFixtureRowResolvesPerContract(
+        array $bucketingMap,
+        string $ruleValue,
+        bool $negated,
+        bool $expectedMatched,
+        bool $expectsWarning,
+        bool $storeOnly
+    ): void {
+        $visitorId = 'mx-fixture-visitor';
+        $configData = MutualExclusionAudienceBuilder::withUnderTestExperience(
+            MutualExclusionAudienceBuilder::loadBaseConfigData(),
+            $ruleValue,
+            $negated
+        );
+
+        $storeDouble = $storeOnly ? new MutualExclusionDataStoreDouble() : null;
+        $built = MutualExclusionDataManagerFactory::build(
+            $configData,
+            $storeDouble !== null ? ['dataStore' => $storeDouble] : []
+        );
+        $dataManager = $built['dataManager'];
+        $ruleManager = $built['ruleManager'];
+        $logManager = $built['logManager'];
+
+        if ($storeOnly) {
+            // Row 8: place the decision ONLY in the persistent store, never
+            // in memory — bypass putData() entirely.
+            $storeDouble->set($dataManager->getStoreKey($visitorId), ['bucketing' => $bucketingMap]);
+        } elseif ($bucketingMap !== []) {
+            $dataManager->putData($visitorId, ['bucketing' => $bucketingMap]);
+        }
+
+        $result = $dataManager->matchRulesByField(
+            $visitorId,
+            MutualExclusionAudienceBuilder::UNDER_TEST_EXPERIENCE_KEY,
+            IdentityField::KEY,
+            new BucketingAttributes([
+                'visitorProperties' => [],
+                'ignoreLocationProperties' => true,
+            ])
+        );
+
+        self::assertSame(
+            $expectedMatched,
+            $result !== null,
+            sprintf(
+                'Row expected matched=%s but matchRulesByField() returned %s',
+                $expectedMatched ? 'true' : 'false',
+                $result === null ? 'null' : 'non-null'
+            )
+        );
+
+        self::assertGreaterThan(
+            0,
+            $ruleManager->isRuleMatchedCallCount,
+            'RuleManager::isRuleMatched() must be invoked even with empty visitorProperties '
+                . 'once the audience carries a bucketed_into_experience_key rule '
+                . '(DataManager.php:410 gate must widen for AC4).'
+        );
+
+        if ($expectsWarning) {
+            self::assertTrue(
+                $logManager->hasWarnContaining($ruleValue),
+                sprintf(
+                    'Expected a warn log naming unresolved target key "%s" '
+                        . '(ErrorMessages::BUCKETING_EXCLUSION_TARGET_NOT_FOUND, AC8).',
+                    $ruleValue
+                )
+            );
+        }
+    }
+}

--- a/packages/Data/tests/Support/MutualExclusionTestSupport.php
+++ b/packages/Data/tests/Support/MutualExclusionTestSupport.php
@@ -451,18 +451,19 @@ final class MutualExclusionAudienceBuilder
     }
 
     /**
-     * AC1/AC4/AC8/AC5: appends a synthetic "exp-under-test" experience whose
-     * SOLE audience is the exclusion rule — isolated from exp-a/exp-b so the
-     * fixture's bucketing-map rows never interact with exp-under-test's own
-     * bucketing state.
+     * Shared shape for the synthetic "exp-under-test" experience, parameterized
+     * only by which audience id(s) it carries. Used by both
+     * withUnderTestExperience() (exclusion-rule audience) and
+     * withGenericOnlyUnderTestExperience() (AC7 regression lock — generic-only
+     * audience, no exclusion rule anywhere in the tree) so the two stay in
+     * lockstep and avoid duplicating this ~15-line fixture shape.
      *
-     * @param array<string, mixed> $configData
+     * @param array<int, string> $audienceIds
      * @return array<string, mixed>
      */
-    public static function withUnderTestExperience(array $configData, string $ruleValue, bool $negated): array
+    private static function underTestExperienceShape(array $audienceIds): array
     {
-        $configData['audiences'][] = self::exclusionOnlyAudience($ruleValue, $negated);
-        $configData['experiences'][] = [
+        return [
             'id' => self::UNDER_TEST_EXPERIENCE_ID,
             'name' => 'Mutual Exclusion Under Test',
             'key' => self::UNDER_TEST_EXPERIENCE_KEY,
@@ -470,7 +471,7 @@ final class MutualExclusionAudienceBuilder
             'version' => 6,
             'status' => 'active',
             'environments' => ['live', 'staging'],
-            'audiences' => [self::EXCLUSION_AUDIENCE_ID],
+            'audiences' => $audienceIds,
             'settings' => ['matching_options' => ['audiences' => GenericListMatchingOptions::ALL]],
             'variations' => [[
                 'id' => self::UNDER_TEST_VARIATION_ID,
@@ -482,6 +483,41 @@ final class MutualExclusionAudienceBuilder
                 'traffic_allocation' => 100.0,
             ]],
         ];
+    }
+
+    /**
+     * AC1/AC4/AC8/AC5: appends a synthetic "exp-under-test" experience whose
+     * SOLE audience is the exclusion rule — isolated from exp-a/exp-b so the
+     * fixture's bucketing-map rows never interact with exp-under-test's own
+     * bucketing state.
+     *
+     * @param array<string, mixed> $configData
+     * @return array<string, mixed>
+     */
+    public static function withUnderTestExperience(array $configData, string $ruleValue, bool $negated): array
+    {
+        $configData['audiences'][] = self::exclusionOnlyAudience($ruleValue, $negated);
+        $configData['experiences'][] = self::underTestExperienceShape([self::EXCLUSION_AUDIENCE_ID]);
+        return $configData;
+    }
+
+    /**
+     * AC7 (generic-rule regression lock): appends the SAME synthetic
+     * "exp-under-test" experience shape, but with a SOLE audience that carries
+     * only a generic key/value rule — no bucketed_into_experience_key rule
+     * anywhere in the tree. Used to lock that the qs-03 gate widening at
+     * DataManager.php:410-425 (`$visitorProperties || $hasBucketingExclusionAudience`)
+     * stays scoped strictly to exclusion audiences: a generic-only audience
+     * evaluated with empty visitorProperties must still resolve to null, exactly
+     * as the pre-qs-03 `if ($visitorProperties)` gate did.
+     *
+     * @param array<string, mixed> $configData
+     * @return array<string, mixed>
+     */
+    public static function withGenericOnlyUnderTestExperience(array $configData, string $key, string $value): array
+    {
+        $configData['audiences'][] = self::genericOnlyAudience($key, $value);
+        $configData['experiences'][] = self::underTestExperienceShape([self::GENERIC_AUDIENCE_ID]);
         return $configData;
     }
 

--- a/packages/Data/tests/Support/MutualExclusionTestSupport.php
+++ b/packages/Data/tests/Support/MutualExclusionTestSupport.php
@@ -1,0 +1,617 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConvertSdk\Tests\Support;
+
+// Not PSR-4/classmap autoloadable — same constraint as MutualExclusionFixture.php
+// (composer.json:52 maps `ConvertSdk\Tests\` only to packages/Utils/tests/, and
+// PHPUnit's directory collector only requires `*Test.php`). Consumers MUST
+// `require_once` this file's absolute path before referencing any class below.
+require_once __DIR__ . '/../MutualExclusionFixture.php';
+
+use ConvertSdk\ApiManager;
+use ConvertSdk\BucketingManager;
+use ConvertSdk\Config\DefaultConfig;
+use ConvertSdk\DataManager;
+use ConvertSdk\Enums\LogLevel;
+use ConvertSdk\Enums\RuleError;
+use ConvertSdk\Enums\RuleType;
+use ConvertSdk\Event\EventManager;
+use ConvertSdk\Interfaces\ApiManagerInterface;
+use ConvertSdk\Interfaces\BucketingManagerInterface;
+use ConvertSdk\Interfaces\LogManagerInterface;
+use ConvertSdk\Interfaces\LogMethodMapInterface;
+use ConvertSdk\Interfaces\RuleManagerInterface;
+use ConvertSdk\RuleManager;
+use ConvertSdk\Tests\MutualExclusionFixture;
+use ConvertSdk\Utils\ObjectUtils;
+use Http\Mock\Client as MockHttpClient;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use OpenAPI\Client\Config;
+use OpenAPI\Client\Model\ConfigAudienceTypes;
+use OpenAPI\Client\Model\ConfigResponseData;
+use OpenAPI\Client\Model\GenericListMatchingOptions;
+use OpenAPI\Client\Model\RuleElement;
+use OpenAPI\Client\Model\RuleObject;
+use OpenAPI\Client\Model\VisitorSegments;
+use OpenAPI\Client\Model\VisitorTrackingEvents;
+use Psr\Log\AbstractLogger;
+
+/**
+ * qs-03 (mutual-exclusion audience rule) test doubles + fixtures shared across
+ * every PHP-3 (RED phase) test file. All classes are plain decorators around
+ * the REAL production collaborators — they never fake the algorithm under
+ * test, they only observe it, so a passing assertion always reflects genuine
+ * production behavior.
+ */
+
+/**
+ * Records every isRuleMatched() invocation while delegating to a real
+ * RuleManagerInterface. Used to prove the audience-evaluation seam was
+ * actually entered (not gate-skipped) — see MutualExclusionRuleResolutionTest.
+ */
+final class SpyRuleManager implements RuleManagerInterface
+{
+    public int $isRuleMatchedCallCount = 0;
+
+    /** @var array<int, array{data: array<string, mixed>, ruleSet: RuleObject, logEntry: ?string, result: bool|RuleError}> */
+    public array $calls = [];
+
+    public function __construct(private readonly RuleManagerInterface $real)
+    {
+    }
+
+    public function getComparisonProcessorMethods(): array
+    {
+        return $this->real->getComparisonProcessorMethods();
+    }
+
+    public function isRuleMatched(array $data, RuleObject $ruleSet, ?string $logEntry = null): bool|RuleError
+    {
+        $this->isRuleMatchedCallCount++;
+        $result = $this->real->isRuleMatched($data, $ruleSet, $logEntry);
+        $this->calls[] = ['data' => $data, 'ruleSet' => $ruleSet, 'logEntry' => $logEntry, 'result' => $result];
+        return $result;
+    }
+
+    public function isValidRule(RuleElement $rule): bool
+    {
+        return $this->real->isValidRule($rule);
+    }
+
+    /**
+     * Returns the `result` of the LAST recorded isRuleMatched() call whose
+     * `logEntry` contains $needle (e.g. an audience id), or null if none
+     * matched. Lets a test pin one specific audience's resolution
+     * independently of the overall ALL/ANY aggregate (see
+     * MutualExclusionCombinationTest).
+     */
+    public function lastResultForLogEntryContaining(string $needle): bool|RuleError|null
+    {
+        for ($i = count($this->calls) - 1; $i >= 0; $i--) {
+            if (($this->calls[$i]['logEntry'] ?? null) !== null && str_contains($this->calls[$i]['logEntry'], $needle)) {
+                return $this->calls[$i]['result'];
+            }
+        }
+        return null;
+    }
+}
+
+/**
+ * Records every getBucketForVisitor()/getBucketForVisitorAnchored() call's
+ * `experienceId` option while delegating to a real BucketingManagerInterface.
+ * Used by AC5 to prove the mutual-exclusion check never buckets its target.
+ */
+final class SpyBucketingManager implements BucketingManagerInterface
+{
+    /** @var array<int, string|null> experienceId option per bucketing call */
+    public array $bucketedExperienceIds = [];
+
+    public function __construct(private readonly BucketingManagerInterface $real)
+    {
+    }
+
+    public function selectBucket(array $buckets, float $value, float $redistribute = 0.0): ?string
+    {
+        return $this->real->selectBucket($buckets, $value, $redistribute);
+    }
+
+    public function getValueVisitorBased(string $visitorId, ?array $options = null): int
+    {
+        return $this->real->getValueVisitorBased($visitorId, $options);
+    }
+
+    public function getBucketForVisitor(array $buckets, string $visitorId, ?array $options = null): ?array
+    {
+        $this->bucketedExperienceIds[] = $options['experienceId'] ?? null;
+        return $this->real->getBucketForVisitor($buckets, $visitorId, $options);
+    }
+
+    public function getBucketRanges(array $allocations): array
+    {
+        return $this->real->getBucketRanges($allocations);
+    }
+
+    public function selectBucketAnchored(array $ranges, float $value): ?string
+    {
+        return $this->real->selectBucketAnchored($ranges, $value);
+    }
+
+    public function getBucketForVisitorAnchored(array $allocations, string $visitorId, ?array $options = null): ?array
+    {
+        $this->bucketedExperienceIds[] = $options['experienceId'] ?? null;
+        return $this->real->getBucketForVisitorAnchored($allocations, $visitorId, $options);
+    }
+
+    public function resetSpy(): void
+    {
+        $this->bucketedExperienceIds = [];
+    }
+}
+
+/**
+ * Records every enqueue() call's visitorId while delegating to a real
+ * ApiManagerInterface. Used by AC5 to prove the mutual-exclusion check never
+ * fires a tracking event.
+ */
+final class SpyApiManager implements ApiManagerInterface
+{
+    /** @var array<int, string> */
+    public array $enqueuedVisitorIds = [];
+
+    public function __construct(private readonly ApiManagerInterface $real)
+    {
+    }
+
+    public function request(string $method, array $path, array $data = [], array $headers = []): array
+    {
+        return $this->real->request($method, $path, $data, $headers);
+    }
+
+    public function enqueue(string $visitorId, VisitorTrackingEvents $eventRequest, ?VisitorSegments $segments = null): void
+    {
+        $this->enqueuedVisitorIds[] = $visitorId;
+        $this->real->enqueue($visitorId, $eventRequest, $segments);
+    }
+
+    public function releaseQueue(?string $reason = null): void
+    {
+        $this->real->releaseQueue($reason);
+    }
+
+    public function enableTracking(): void
+    {
+        $this->real->enableTracking();
+    }
+
+    public function disableTracking(): void
+    {
+        $this->real->disableTracking();
+    }
+
+    public function setData(ConfigResponseData $data): void
+    {
+        $this->real->setData($data);
+    }
+
+    public function getConfig(): ConfigResponseData
+    {
+        return $this->real->getConfig();
+    }
+
+    public function getConfigForExperience(string $experienceId): ConfigResponseData
+    {
+        return $this->real->getConfigForExperience($experienceId);
+    }
+
+    public function resetSpy(): void
+    {
+        $this->enqueuedVisitorIds = [];
+    }
+}
+
+/**
+ * Records every warn() call (and every call at any level) while satisfying
+ * LogManagerInterface. Used by AC8 (unknown-target warning) and AC5 (no
+ * side-effecting log path is exercised as a proxy is unnecessary — kept
+ * intentionally minimal, no delegation needed since assertions only read
+ * recorded calls).
+ */
+final class SpyLogManager implements LogManagerInterface
+{
+    /** @var array<int, array<int, mixed>> */
+    public array $warnCalls = [];
+
+    /** @var array<int, array{level: string, args: array<int, mixed>}> */
+    public array $allCalls = [];
+
+    public function log(LogLevel $level, mixed ...$args): void
+    {
+        $this->allCalls[] = ['level' => $level->value, 'args' => $args];
+    }
+
+    public function trace(mixed ...$args): void
+    {
+        $this->allCalls[] = ['level' => 'trace', 'args' => $args];
+    }
+
+    public function debug(mixed ...$args): void
+    {
+        $this->allCalls[] = ['level' => 'debug', 'args' => $args];
+    }
+
+    public function info(mixed ...$args): void
+    {
+        $this->allCalls[] = ['level' => 'info', 'args' => $args];
+    }
+
+    public function warn(mixed ...$args): void
+    {
+        $this->warnCalls[] = $args;
+        $this->allCalls[] = ['level' => 'warn', 'args' => $args];
+    }
+
+    public function error(mixed ...$args): void
+    {
+        $this->allCalls[] = ['level' => 'error', 'args' => $args];
+    }
+
+    public function addClient(mixed $client = null, ?LogLevel $level = null, ?LogMethodMapInterface $methodMap = null): void
+    {
+        // No-op: this spy never fans out to a real client, only records.
+    }
+
+    public function setClientLevel(LogLevel $level, mixed $client = null): void
+    {
+        // No-op: see addClient().
+    }
+
+    /** True iff any warn() call contains a string argument (recursively) containing $needle. */
+    public function hasWarnContaining(string $needle): bool
+    {
+        foreach ($this->warnCalls as $args) {
+            if ($this->argsContain($args, $needle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function argsContain(mixed $value, string $needle): bool
+    {
+        if (is_string($value)) {
+            return str_contains($value, $needle);
+        }
+        if (is_array($value)) {
+            foreach ($value as $item) {
+                if ($this->argsContain($item, $needle)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}
+
+/**
+ * PSR-3 logger capturing every message, for use as a `logger.customLoggers`
+ * entry via the PUBLIC ConvertSDK::create() config (`'logger' =>
+ * ['logLevel' => LogLevel::Trace, 'customLoggers' => [$capture]]`).
+ *
+ * Used by integration tests that only have the public Context/ConvertSDK API
+ * available (no internal RuleManager DI seam like MutualExclusionDataManagerFactory
+ * provides at the DataManager-unit level) to prove that DataManager's
+ * audience-evaluation path (filterMatchedRecordsWithRule(), which LogManager
+ * traces unconditionally on every call — DataManager.php:1363) was genuinely
+ * entered, rather than skipped by the AC4 line-410 gate. LogManager
+ * concatenates every trace() arg into a single string and forwards it to a
+ * PSR-3 client's debug() method (trace maps to 'debug' in
+ * LogManager::$_monologMapping) — see LogManager.php:_log().
+ */
+final class MutualExclusionLogCapture extends AbstractLogger
+{
+    /** @var array<int, string> */
+    public array $messages = [];
+
+    public function log($level, $message, array $context = []): void
+    {
+        $this->messages[] = (string) $message;
+    }
+
+    public function hasMessageContaining(string $needle): bool
+    {
+        foreach ($this->messages as $message) {
+            if (str_contains($message, $needle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+/**
+ * Minimal PSR-16-shaped (get/set) persistent-store double. Distinct from
+ * DataManager's in-memory `_bucketedVisitors` — writing directly to this
+ * double (bypassing DataManager::putData()) is how AC3/row 8 places a
+ * decision ONLY in the persistent layer, never in memory.
+ */
+final class MutualExclusionDataStoreDouble
+{
+    /** @var array<string, mixed> */
+    private array $store = [];
+
+    /** @var array<int, string> keys passed to set() */
+    public array $setCalls = [];
+
+    public function get(string $key): mixed
+    {
+        return $this->store[$key] ?? null;
+    }
+
+    public function set(string $key, mixed $value): void
+    {
+        $this->setCalls[] = $key;
+        $this->store[$key] = $value;
+    }
+
+    public function resetSpy(): void
+    {
+        $this->setCalls = [];
+    }
+}
+
+/**
+ * Builds config-data fragments (audiences + a synthetic experience) that
+ * carry a `bucketed_into_experience_key` rule, layered on top of the shared
+ * mutual-exclusion-config.json fixture. Never mutates the JSON file itself —
+ * every method returns a new in-memory `data` array.
+ */
+final class MutualExclusionAudienceBuilder
+{
+    /** Synthetic third experience — isolated from exp-a/exp-b (AC1/AC4/AC8/AC5). */
+    public const UNDER_TEST_EXPERIENCE_ID = '100333';
+    public const UNDER_TEST_EXPERIENCE_KEY = 'exp-under-test';
+    public const UNDER_TEST_VARIATION_ID = '100903';
+
+    public const EXCLUSION_AUDIENCE_ID = '100777';
+    public const EXCLUSION_AUDIENCE_KEY = 'mx-exclusion-audience';
+    public const GENERIC_AUDIENCE_ID = '100778';
+    public const GENERIC_AUDIENCE_KEY = 'mx-generic-audience';
+
+    /** @return array<string, mixed> the decoded `data` object of mutual-exclusion-config.json */
+    public static function loadBaseConfigData(): array
+    {
+        $decoded = json_decode(
+            (string) file_get_contents(__DIR__ . '/../mutual-exclusion-config.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        return $decoded['data'];
+    }
+
+    /** @return array{rule_type: string, matching: array{match_type: string, negated: bool}, value: string} */
+    public static function exclusionRuleElement(string $targetExperienceKey, bool $negated): array
+    {
+        return [
+            'rule_type' => RuleType::BucketedIntoExperienceKey->value,
+            'matching' => ['match_type' => 'equals', 'negated' => $negated],
+            'value' => $targetExperienceKey,
+        ];
+    }
+
+    /** @return array{rule_type: string, matching: array{match_type: string, negated: bool}, value: string, key: string} */
+    public static function genericRuleElement(string $key, string $value, bool $negated = false): array
+    {
+        return [
+            'rule_type' => 'generic_key_value',
+            'matching' => ['match_type' => 'matches', 'negated' => $negated],
+            'value' => $value,
+            'key' => $key,
+        ];
+    }
+
+    /** @param array<string, mixed> $ruleElement */
+    private static function singleRuleAudience(string $id, string $key, array $ruleElement): array
+    {
+        return [
+            'id' => $id,
+            'name' => $key,
+            'type' => ConfigAudienceTypes::TRANSIENT,
+            'status' => 'active',
+            'key' => $key,
+            'preset' => false,
+            'rules' => [
+                'OR' => [
+                    ['AND' => [
+                        ['OR_WHEN' => [$ruleElement]],
+                    ]],
+                ],
+            ],
+        ];
+    }
+
+    public static function exclusionOnlyAudience(string $targetExperienceKey, bool $negated): array
+    {
+        return self::singleRuleAudience(
+            self::EXCLUSION_AUDIENCE_ID,
+            self::EXCLUSION_AUDIENCE_KEY,
+            self::exclusionRuleElement($targetExperienceKey, $negated)
+        );
+    }
+
+    public static function genericOnlyAudience(string $key, string $value, bool $negated = false): array
+    {
+        return self::singleRuleAudience(
+            self::GENERIC_AUDIENCE_ID,
+            self::GENERIC_AUDIENCE_KEY,
+            self::genericRuleElement($key, $value, $negated)
+        );
+    }
+
+    /**
+     * AC1/AC4/AC8/AC5: appends a synthetic "exp-under-test" experience whose
+     * SOLE audience is the exclusion rule — isolated from exp-a/exp-b so the
+     * fixture's bucketing-map rows never interact with exp-under-test's own
+     * bucketing state.
+     *
+     * @param array<string, mixed> $configData
+     * @return array<string, mixed>
+     */
+    public static function withUnderTestExperience(array $configData, string $ruleValue, bool $negated): array
+    {
+        $configData['audiences'][] = self::exclusionOnlyAudience($ruleValue, $negated);
+        $configData['experiences'][] = [
+            'id' => self::UNDER_TEST_EXPERIENCE_ID,
+            'name' => 'Mutual Exclusion Under Test',
+            'key' => self::UNDER_TEST_EXPERIENCE_KEY,
+            'type' => 'a/b_fullstack',
+            'version' => 6,
+            'status' => 'active',
+            'environments' => ['live', 'staging'],
+            'audiences' => [self::EXCLUSION_AUDIENCE_ID],
+            'settings' => ['matching_options' => ['audiences' => GenericListMatchingOptions::ALL]],
+            'variations' => [[
+                'id' => self::UNDER_TEST_VARIATION_ID,
+                'name' => 'Original',
+                'status' => 'running',
+                'is_baseline' => true,
+                'changes' => [],
+                'key' => self::UNDER_TEST_VARIATION_ID . '-original',
+                'traffic_allocation' => 100.0,
+            ]],
+        ];
+        return $configData;
+    }
+
+    /**
+     * AC2/AC3/AC4: attaches the negated exclusion audience (targeting exp-a)
+     * directly onto the real exp-b, with `matching_options.audiences = all`.
+     *
+     * @param array<string, mixed> $configData
+     * @return array<string, mixed>
+     */
+    public static function withExclusionOnExperienceB(array $configData, bool $negated = true): array
+    {
+        $configData['audiences'][] = self::exclusionOnlyAudience(MutualExclusionFixture::EXPERIENCE_A_KEY, $negated);
+        foreach ($configData['experiences'] as &$experience) {
+            if ($experience['key'] === MutualExclusionFixture::EXPERIENCE_B_KEY) {
+                $experience['audiences'] = [self::EXCLUSION_AUDIENCE_ID];
+                $experience['settings'] = ['matching_options' => ['audiences' => GenericListMatchingOptions::ALL]];
+            }
+        }
+        unset($experience);
+        return $configData;
+    }
+
+    /**
+     * AC6: attaches BOTH a generic key/value audience and the exclusion
+     * audience onto the real exp-b, with a configurable
+     * `matching_options.audiences` (all/any).
+     *
+     * @param array<string, mixed> $configData
+     * @return array<string, mixed>
+     */
+    public static function withCombinedAudiencesOnExperienceB(
+        array $configData,
+        string $matchingOption,
+        string $genericKey,
+        string $genericValue,
+        bool $exclusionNegated = true
+    ): array {
+        $configData['audiences'][] = self::genericOnlyAudience($genericKey, $genericValue);
+        $configData['audiences'][] = self::exclusionOnlyAudience(MutualExclusionFixture::EXPERIENCE_A_KEY, $exclusionNegated);
+        foreach ($configData['experiences'] as &$experience) {
+            if ($experience['key'] === MutualExclusionFixture::EXPERIENCE_B_KEY) {
+                $experience['audiences'] = [self::GENERIC_AUDIENCE_ID, self::EXCLUSION_AUDIENCE_ID];
+                $experience['settings'] = ['matching_options' => ['audiences' => $matchingOption]];
+            }
+        }
+        unset($experience);
+        return $configData;
+    }
+}
+
+/**
+ * Wires a fully-functional DataManager (config + real BucketingManager +
+ * spy-wrapped RuleManager/ApiManager/BucketingManager + SpyLogManager) over
+ * a given `data` array, mirroring DataManagerTest's setUp() so PHP-3 tests
+ * don't duplicate that ~30-line wiring block per file (SonarCloud
+ * duplication gate — see .claude/rules/sonarqube-new-code-duplication.md).
+ */
+final class MutualExclusionDataManagerFactory
+{
+    /**
+     * @param array<string, mixed> $data The `data` array (post-builder augmentation)
+     * @param array{
+     *   dataStore?: MutualExclusionDataStoreDouble,
+     *   ruleManager?: RuleManagerInterface,
+     *   bucketingManager?: BucketingManagerInterface,
+     *   apiManager?: ApiManagerInterface,
+     *   logManager?: LogManagerInterface,
+     * } $overrides
+     * @return array{
+     *   dataManager: DataManager,
+     *   ruleManager: SpyRuleManager|RuleManagerInterface,
+     *   bucketingManager: SpyBucketingManager|BucketingManagerInterface,
+     *   apiManager: SpyApiManager|ApiManagerInterface,
+     *   logManager: SpyLogManager|LogManagerInterface,
+     * }
+     */
+    public static function build(array $data, array $overrides = []): array
+    {
+        $baseConfig = json_decode(
+            (string) file_get_contents(__DIR__ . '/../mutual-exclusion-config.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $defaultConfig = DefaultConfig::getDefault();
+        $mergedConfig = ObjectUtils::objectDeepMerge($baseConfig, $defaultConfig, [
+            'api' => [
+                'endpoint' => [
+                    'config' => 'http://localhost:8099',
+                    'track' => 'http://localhost:8099',
+                ],
+            ],
+        ]);
+        $mergedConfig['data'] = new ConfigResponseData($data);
+        unset($mergedConfig['sdkKey']);
+        $config = new Config($mergedConfig);
+
+        $mockHttpClient = new MockHttpClient();
+        $psr17Factory = new Psr17Factory();
+
+        $bucketingConfig = $config->getBucketing();
+        $realBucketingManager = new BucketingManager(
+            maxTraffic: $bucketingConfig['max_traffic'] ?? 10000,
+            hashSeed: $bucketingConfig['hash_seed'] ?? 9999,
+        );
+        $bucketingManager = $overrides['bucketingManager'] ?? new SpyBucketingManager($realBucketingManager);
+
+        $realRuleManager = new RuleManager();
+        $ruleManager = $overrides['ruleManager'] ?? new SpyRuleManager($realRuleManager);
+
+        $eventManager = new EventManager();
+
+        $realApiManager = new ApiManager($config, $eventManager, null, $mockHttpClient, $psr17Factory, $psr17Factory);
+        $apiManager = $overrides['apiManager'] ?? new SpyApiManager($realApiManager);
+
+        $logManager = $overrides['logManager'] ?? new SpyLogManager();
+
+        $dataManager = new DataManager($config, $bucketingManager, $ruleManager, $eventManager, $apiManager, $logManager);
+
+        if (isset($overrides['dataStore'])) {
+            $dataManager->setDataStore($overrides['dataStore']);
+        }
+
+        return [
+            'dataManager' => $dataManager,
+            'ruleManager' => $ruleManager,
+            'bucketingManager' => $bucketingManager,
+            'apiManager' => $apiManager,
+            'logManager' => $logManager,
+        ];
+    }
+}

--- a/packages/Data/tests/mutual-exclusion-config.json
+++ b/packages/Data/tests/mutual-exclusion-config.json
@@ -1,0 +1,57 @@
+{
+  "environment": "staging",
+  "data": {
+    "account_id": "900000",
+    "project": {
+      "id": "900001",
+      "name": "qs-03 Mutual Exclusion Test Project",
+      "type": "fullstack"
+    },
+    "audiences": [],
+    "segments": [],
+    "features": [],
+    "goals": [],
+    "experiences": [
+      {
+        "id": "100111",
+        "name": "Mutual Exclusion Experience A",
+        "key": "exp-a",
+        "type": "a/b_fullstack",
+        "version": 6,
+        "status": "active",
+        "environments": ["live", "staging"],
+        "variations": [
+          {
+            "id": "100901",
+            "name": "Original",
+            "status": "running",
+            "is_baseline": true,
+            "changes": [],
+            "key": "100901-original",
+            "traffic_allocation": 100.0
+          }
+        ]
+      },
+      {
+        "id": "100222",
+        "name": "Mutual Exclusion Experience B",
+        "key": "exp-b",
+        "type": "a/b_fullstack",
+        "version": 6,
+        "status": "active",
+        "environments": ["live", "staging"],
+        "variations": [
+          {
+            "id": "100902",
+            "name": "Original",
+            "status": "running",
+            "is_baseline": true,
+            "changes": [],
+            "key": "100902-original",
+            "traffic_allocation": 100.0
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/Enums/src/ErrorMessages.php
+++ b/packages/Enums/src/ErrorMessages.php
@@ -22,4 +22,7 @@ final class ErrorMessages
     public const UNABLE_TO_SELECT_BUCKET_FOR_VISITOR = 'Unable to bucket visitor';
     public const UNABLE_TO_PERFORM_NETWORK_REQUEST = 'Unable to perform network request';
     public const UNSUPPORTED_RESPONSE_TYPE = 'Unsupported response type';
+
+    // qs-03 (mutual-exclusion audience rule, bucketed_into_experience_key) — AC8
+    public const BUCKETING_EXCLUSION_TARGET_NOT_FOUND = 'Mutual exclusion target experience key "#" not found in config';
 }

--- a/packages/Enums/src/ErrorMessages.php
+++ b/packages/Enums/src/ErrorMessages.php
@@ -22,7 +22,4 @@ final class ErrorMessages
     public const UNABLE_TO_SELECT_BUCKET_FOR_VISITOR = 'Unable to bucket visitor';
     public const UNABLE_TO_PERFORM_NETWORK_REQUEST = 'Unable to perform network request';
     public const UNSUPPORTED_RESPONSE_TYPE = 'Unsupported response type';
-
-    // qs-03 (mutual-exclusion audience rule, bucketed_into_experience_key) — AC8
-    public const BUCKETING_EXCLUSION_TARGET_NOT_FOUND = 'Mutual exclusion target experience key "#" not found in config';
 }

--- a/packages/Enums/src/Messages.php
+++ b/packages/Enums/src/Messages.php
@@ -66,4 +66,7 @@ final class Messages
     // qs-02 capability (B) preview input
     public const PREVIEW_EXPERIENCE_NOT_FOUND = 'Preview experience not found in config or via exp= fetch';
     public const PREVIEW_VARIATION_NOT_FOUND = 'Preview variation not found on the resolved experience';
+
+    // qs-03 (mutual-exclusion audience rule, bucketed_into_experience_key) — AC8
+    public const BUCKETING_EXCLUSION_TARGET_NOT_FOUND = 'Mutual exclusion target experience key "#" not found in config';
 }

--- a/packages/Enums/src/RuleType.php
+++ b/packages/Enums/src/RuleType.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConvertSdk\Enums;
+
+enum RuleType: string
+{
+    case BucketedIntoExperienceKey = 'bucketed_into_experience_key';
+}

--- a/packages/Enums/tests/MutualExclusionRuleConstantsTest.php
+++ b/packages/Enums/tests/MutualExclusionRuleConstantsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConvertSdk\Tests;
+
+use ConvertSdk\Enums\ErrorMessages;
+use ConvertSdk\Enums\RuleType;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * qs-03 (mutual-exclusion audience rule, `bucketed_into_experience_key`) — PHP-1.
+ *
+ * Covers the two Enums-package constants a later story (PHP-3) will consume
+ * when implementing the rule-matching logic itself:
+ *  - the AC8 unknown-target warning message (placeholder-bearing)
+ *  - the `bucketed_into_experience_key` rule-type literal
+ */
+class MutualExclusionRuleConstantsTest extends TestCase
+{
+    public function testBucketingExclusionTargetNotFoundContainsPlaceholder(): void
+    {
+        $this->assertStringContainsString('#', ErrorMessages::BUCKETING_EXCLUSION_TARGET_NOT_FOUND);
+    }
+
+    public function testRuleTypeBucketedIntoExperienceKeyValue(): void
+    {
+        $this->assertSame('bucketed_into_experience_key', RuleType::BucketedIntoExperienceKey->value);
+    }
+}

--- a/packages/Enums/tests/MutualExclusionRuleConstantsTest.php
+++ b/packages/Enums/tests/MutualExclusionRuleConstantsTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ConvertSdk\Tests;
 
-use ConvertSdk\Enums\ErrorMessages;
+use ConvertSdk\Enums\Messages;
 use ConvertSdk\Enums\RuleType;
 use PHPUnit\Framework\TestCase;
 
@@ -20,7 +20,7 @@ class MutualExclusionRuleConstantsTest extends TestCase
 {
     public function testBucketingExclusionTargetNotFoundContainsPlaceholder(): void
     {
-        $this->assertStringContainsString('#', ErrorMessages::BUCKETING_EXCLUSION_TARGET_NOT_FOUND);
+        $this->assertStringContainsString('#', Messages::BUCKETING_EXCLUSION_TARGET_NOT_FOUND);
     }
 
     public function testRuleTypeBucketedIntoExperienceKeyValue(): void

--- a/packages/Php-sdk/tests/MutualExclusionIntegrationTest.php
+++ b/packages/Php-sdk/tests/MutualExclusionIntegrationTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConvertSdk\Tests;
+
+require_once __DIR__ . '/../../Data/tests/MutualExclusionFixture.php';
+require_once __DIR__ . '/../../Data/tests/Support/MutualExclusionTestSupport.php';
+
+use ConvertSdk\ConvertSDK;
+use ConvertSdk\Core;
+use ConvertSdk\DTO\BucketedVariation;
+use ConvertSdk\Enums\LogLevel;
+use ConvertSdk\Tests\Support\MutualExclusionAudienceBuilder;
+use ConvertSdk\Tests\Support\MutualExclusionLogCapture;
+use OpenAPI\Client\BucketingAttributes;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * qs-03 (mutual-exclusion audience rule) — AC2 (end-to-end exclusion), AC4
+ * (zero new inputs), through the PUBLIC Context API
+ * (Context::runExperience(), see packages/Php-sdk/src/Context.php:172).
+ *
+ * Modeled on tests/Integration/FullChainIntegrationTest.php's
+ * `ConvertSDK::create(['data' => ..., 'environment' => ..., 'network' =>
+ * ['tracking' => false]])` + `createContext()->runExperience()` pattern.
+ *
+ * Config: the real exp-a/exp-b from mutual-exclusion-config.json, with the
+ * negated `bucketed_into_experience_key` rule (targeting exp-a) attached as
+ * exp-b's SOLE audience (`matching_options.audiences = all`) — see
+ * MutualExclusionAudienceBuilder::withExclusionOnExperienceB().
+ *
+ * AC4: no visitorAttributes are ever passed to createContext(), and no
+ * visitorProperties are ever set on the BucketingAttributes passed to
+ * runExperience() — Context::getVisitorProperties() resolves this to `[]`.
+ * `ignoreLocationProperties: true` is set purely to bypass the (unrelated)
+ * location-matching gate at DataManager.php:353-397, which independently
+ * requires either locationProperties or ignoreLocationProperties for ANY
+ * experience lacking a location restriction — orthogonal to qs-03, and not
+ * a "new application input" in the AC4 sense (it carries no visitor data).
+ *
+ * Genuineness note: for the "excluded" scenario, DataManager.php:410's
+ * current `if ($visitorProperties)` gate ALSO happens to return null with
+ * `[]` properties (audience block skipped entirely) — the SAME null a
+ * correct exclusion would produce. To avoid a coincidental pass, this test
+ * additionally injects a `logger.customLoggers` PSR-3 capture (public config
+ * — see ConvertSDK::create()'s `logger.logLevel`/`logger.customLoggers`) and
+ * asserts DataManager::filterMatchedRecordsWithRule() was actually invoked
+ * (it traces unconditionally on every call, DataManager.php:1363..1371) —
+ * proving the audience block was genuinely entered, not gate-skipped.
+ */
+final class MutualExclusionIntegrationTest extends TestCase
+{
+    private function noLocationGateAttributes(): BucketingAttributes
+    {
+        return new BucketingAttributes(['ignoreLocationProperties' => true]);
+    }
+
+    /** @return array{sdk: Core, logCapture: MutualExclusionLogCapture} */
+    private function createSdkWithLogCapture(): array
+    {
+        $configData = MutualExclusionAudienceBuilder::withExclusionOnExperienceB(
+            MutualExclusionAudienceBuilder::loadBaseConfigData()
+        );
+        $logCapture = new MutualExclusionLogCapture();
+        $sdk = ConvertSDK::create([
+            'data' => $configData,
+            'environment' => 'staging',
+            'network' => ['tracking' => false],
+            'logger' => [
+                'logLevel' => LogLevel::Trace,
+                'customLoggers' => [$logCapture],
+            ],
+        ]);
+
+        return ['sdk' => $sdk, 'logCapture' => $logCapture];
+    }
+
+    public function testVisitorBucketedIntoExpAIsExcludedFromExpB(): void
+    {
+        ['sdk' => $sdk, 'logCapture' => $logCapture] = $this->createSdkWithLogCapture();
+        $context = $sdk->createContext('mx-ac2-visitor-excluded');
+
+        $variationA = $context->runExperience(MutualExclusionFixture::EXPERIENCE_A_KEY, $this->noLocationGateAttributes());
+        self::assertInstanceOf(BucketedVariation::class, $variationA, 'Visitor must bucket into exp-a first.');
+
+        $variationB = $context->runExperience(MutualExclusionFixture::EXPERIENCE_B_KEY, $this->noLocationGateAttributes());
+
+        self::assertTrue(
+            $logCapture->hasMessageContaining('filterMatchedRecordsWithRule'),
+            'DataManager::filterMatchedRecordsWithRule() must be invoked even with empty visitorProperties '
+                . 'once exp-b\'s audience carries a bucketed_into_experience_key rule '
+                . '(DataManager.php:410 gate must widen for AC4) — otherwise a null result below is coincidental, not a real exclusion.'
+        );
+        self::assertNull($variationB, 'Visitor already bucketed into exp-a must be excluded from exp-b.');
+    }
+
+    public function testVisitorWhoNeverRanExpABucketsIntoExpBNormally(): void
+    {
+        ['sdk' => $sdk] = $this->createSdkWithLogCapture();
+        $context = $sdk->createContext('mx-ac2-visitor-unbucketed');
+
+        $variationB = $context->runExperience(MutualExclusionFixture::EXPERIENCE_B_KEY, $this->noLocationGateAttributes());
+        self::assertInstanceOf(
+            BucketedVariation::class,
+            $variationB,
+            'A visitor who never ran exp-a must bucket into exp-b normally (negated exclusion dissolves).'
+        );
+    }
+}

--- a/packages/Php-sdk/tests/MutualExclusionPersistenceTest.php
+++ b/packages/Php-sdk/tests/MutualExclusionPersistenceTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConvertSdk\Tests;
+
+require_once __DIR__ . '/../../Data/tests/MutualExclusionFixture.php';
+require_once __DIR__ . '/../../Data/tests/Support/MutualExclusionTestSupport.php';
+
+use ConvertSdk\ConvertSDK;
+use ConvertSdk\DTO\BucketedVariation;
+use ConvertSdk\Enums\LogLevel;
+use ConvertSdk\Tests\Support\MutualExclusionAudienceBuilder;
+use ConvertSdk\Tests\Support\MutualExclusionDataStoreDouble;
+use ConvertSdk\Tests\Support\MutualExclusionLogCapture;
+use OpenAPI\Client\BucketingAttributes;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * qs-03 (mutual-exclusion audience rule) — AC3 (persistence, fixture row 8),
+ * through the PUBLIC ConvertSDK/Context API.
+ *
+ * Contract (qs-03-mutual-exclusion-rule.md line 83): "With a persistent
+ * store backing: A's decision written in one request excludes the visitor
+ * from B in a NEW request/SDK instance."
+ *
+ * Two SEPARATE ConvertSDK::create() instances (fresh Core/DataManager memory
+ * each — `_bucketedVisitors` never shared) wired to the SAME
+ * MutualExclusionDataStoreDouble via the public `dataStore` config key
+ * (ConvertSDK.php:156-157: `$dataStore = $configuration['dataStore'] ?? $cache;
+ * $dataManager->setDataStore($dataStore);`). The second instance's DataManager
+ * has an empty in-memory store for this visitor — its getData() can ONLY see
+ * exp-a's decision by reading it back out of the shared store, exactly
+ * fixture row 8 ("bucketed only in the persistent store").
+ *
+ * Genuineness note: like MutualExclusionIntegrationTest's "excluded"
+ * scenario, DataManager.php:410's current `if ($visitorProperties)` gate
+ * ALSO returns null for `[]` properties regardless of the store — so a bare
+ * `assertNull($variationB)` would coincidentally pass today without any real
+ * cross-instance persistence check. A `logger.customLoggers` PSR-3 capture
+ * (public config, see ConvertSDK::create()) proves
+ * DataManager::filterMatchedRecordsWithRule() was genuinely invoked on
+ * $sdk2's instance (it traces unconditionally on every call,
+ * DataManager.php:1363..1371).
+ */
+final class MutualExclusionPersistenceTest extends TestCase
+{
+    public function testExpADecisionInOneInstanceExcludesVisitorFromExpBInANewInstance(): void
+    {
+        $configData = MutualExclusionAudienceBuilder::withExclusionOnExperienceB(
+            MutualExclusionAudienceBuilder::loadBaseConfigData()
+        );
+        $sharedStore = new MutualExclusionDataStoreDouble();
+        $visitorId = 'mx-ac3-visitor';
+        $attributes = new BucketingAttributes(['ignoreLocationProperties' => true]);
+
+        $sdk1 = ConvertSDK::create([
+            'data' => $configData,
+            'environment' => 'staging',
+            'network' => ['tracking' => false],
+            'dataStore' => $sharedStore,
+        ]);
+        $context1 = $sdk1->createContext($visitorId);
+        $variationA = $context1->runExperience(MutualExclusionFixture::EXPERIENCE_A_KEY, $attributes);
+        self::assertInstanceOf(BucketedVariation::class, $variationA, 'First instance must bucket the visitor into exp-a.');
+
+        // Sanity: the shared store double actually received exp-a's write —
+        // otherwise the second instance's exclusion below would be
+        // impossible to attribute to persistence at all.
+        self::assertNotEmpty($sharedStore->setCalls, 'exp-a\'s decision must be written to the shared persistent store.');
+
+        // NEW instance, same shared store, same visitor id — fresh in-memory
+        // DataManager state for this visitor (row 8: bucketing map present
+        // ONLY in the persistent store from this instance's point of view).
+        $logCapture = new MutualExclusionLogCapture();
+        $sdk2 = ConvertSDK::create([
+            'data' => $configData,
+            'environment' => 'staging',
+            'network' => ['tracking' => false],
+            'dataStore' => $sharedStore,
+            'logger' => [
+                'logLevel' => LogLevel::Trace,
+                'customLoggers' => [$logCapture],
+            ],
+        ]);
+        $context2 = $sdk2->createContext($visitorId);
+
+        $variationB = $context2->runExperience(MutualExclusionFixture::EXPERIENCE_B_KEY, $attributes);
+
+        self::assertTrue(
+            $logCapture->hasMessageContaining('filterMatchedRecordsWithRule'),
+            'DataManager::filterMatchedRecordsWithRule() must be invoked on the NEW instance even with empty '
+                . 'visitorProperties (DataManager.php:410 gate must widen for AC4) — otherwise a null result below '
+                . 'is coincidental, not real cross-instance persistence.'
+        );
+        self::assertNull(
+            $variationB,
+            'A visitor bucketed into exp-a by a PRIOR instance must be excluded from exp-b on a NEW instance sharing the same persistent store.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a declarative mutual-exclusion audience rule to the PHP SDK: a new rule type **`bucketed_into_experience_key`** whose value is a **target experience key**. It matches iff the visitor is already bucketed into that experience per the SDK's stored bucketing state (in-memory merged with the cache/DataStore), and combines with `negated: true` to express "NOT in experiment X". **Zero new application inputs** — it works with empty visitor properties.

Inert until served configs carry the new rule type (backend registration is a separate spec). One of six sibling SDK specs; consistency is defined by the shared normative contract + the identical 8-row fixture (parity oracle: JS SDK PR convertcom/javascript-sdk#416).

> **Stacked PR** — base is `feat/experiment-preview` (qs-02), **not** `main`. Do not merge before the base.

## Design

- **RuleManager is byte-unchanged** (strongest AC7 guarantee). Resolution happens DataManager-side via a **synthetic-delegation seam** in `filterMatchedRecordsWithRule`: resolve `bucketedRaw` read-only, then route a synthetic single-key `equals` rule through the unmodified `isRuleMatched()` so negation reuses the real `Comparisons::returnNegationCheck`.
- The PHP-specific empty-visitor-properties gate in `matchRulesByField` (`if ($visitorProperties)`) is widened to `if ($visitorProperties || $hasBucketingExclusionAudience)`, triggered **only** when an audience's rule tree is a sole `bucketed_into_experience_key` element — generic-only audiences keep byte-identical behavior.
- Resolution: `target = getEntity(value,'experiences')`; `bucketedRaw = target !== null && array_key_exists((string)target.id, getData(visitorId).bucketing)`; `matched = negated ? !bucketedRaw : bucketedRaw`. Read-only (no target bucketing, no store writes, no tracking). Unknown target → `false` + warn naming the key.

## Acceptance criteria — evidence

| AC | What | Evidence |
|----|------|----------|
| AC1 | 8-row fixture, single data provider | `MutualExclusionRuleResolutionTest` — `@DataProviderExternal` over `MutualExclusionFixture::rows()`, 8/8 |
| AC2 | End-to-end exclusion | `MutualExclusionIntegrationTest` — run A → buckets; run B (negated audience, ALL) → excluded; fresh visitor buckets B |
| AC3 | Persistence (new instance) | `MutualExclusionPersistenceTest` — decision written via DataStore in instance #1 excludes B in a NEW instance (fixture row 8) |
| AC4 | No new inputs (empty props) | all resolution + integration cases run with `visitorProperties=[]`; the :410 gate is widened for the exclusion rule |
| AC5 | Read-only | `MutualExclusionReadOnlyTest` — spies assert zero target bucketing, zero store writes, zero tracking events |
| AC6 | ALL / ANY combination | `MutualExclusionCombinationTest` — exclusion + generic rule under ALL and ANY |
| AC7 | Generic-rule regression lock | `MutualExclusionGenericRegressionTest` (9 tests) + full suite green; generic text/numeric/bool bit-identical (visitorId passed and null); generic-only + empty props still excluded |
| AC8 | Unknown-target warning | rows 6/7 assert a warn log naming the unresolved key (`Messages::BUCKETING_EXCLUSION_TARGET_NOT_FOUND`) |

## Tests

Full php-sdk suite **1168 tests / 4439 assertions green** (34 pre-existing env skips). New mutual-exclusion suites: **33 tests / 138 assertions**. `phpstan` (level 6, configured `*/src` scope) clean; `php-cs-fixer` clean. `RuleManager.php`, `DataManagerInterface.php`, `Comparisons.php`, `Types/**` byte-unchanged.

## Files

Production: `packages/Data/src/DataManager.php` (seam + 4 private helpers), `packages/Enums/src/RuleType.php` (new backed enum), `packages/Enums/src/Messages.php` (warn constant). Remainder: tests + fixture + config.

## Notes / carry-forward

- Cross-request exclusion requires a persistent cache/DataStore backing (Redis/Memcached); the default in-memory ArrayCache is request-scoped.
- Old SDK versions receiving this rule fail closed (evaluate `false`, negation unapplied) — the guide should recommend `ALL` and state the minimum SDK version.
- A single audience carrying **both** a generic and an exclusion rule in one tree is out of scope (no producer exists yet); the exclusion element fails closed in that case. The backend-registration sibling spec must honor "exclusion rule is the sole rule in its audience".
- "Zero visitor inputs" still requires location matching to be satisfied (tests set `ignoreLocationProperties: true`); worth a release-guide note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
