### PR TITLE
chore(ci): SHA-pin third-party GitHub Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.4'
           tools: composer:v2

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.4'
           tools: composer:v2
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.4'
           tools: composer:v2
@@ -104,7 +104,7 @@ jobs:
         dependency-preference: ['prefer-lowest', 'prefer-stable']
     steps:
       - uses: actions/checkout@v4
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: 'lts/*'
 
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.4'
           tools: composer:v2

--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - if: "!startsWith(github.ref, 'refs/tags/')"
-        uses: danharrin/monorepo-split-github-action@v2.4.4
+        uses: danharrin/monorepo-split-github-action@f10477258c88013cc5902388ec47fe9457837041 # v2.4.4
         with:
           package_directory: ${{ matrix.package.local_path }}
           repository_organization: 'convertcom'
@@ -40,7 +40,7 @@ jobs:
           user_email: 'ci@convert.com'
 
       - if: "startsWith(github.ref, 'refs/tags/')"
-        uses: danharrin/monorepo-split-github-action@v2.4.4
+        uses: danharrin/monorepo-split-github-action@f10477258c88013cc5902388ec47fe9457837041 # v2.4.4
         with:
           tag: ${{ github.ref_name }}
           package_directory: ${{ matrix.package.local_path }}


### PR DESCRIPTION
## What

Supply-chain hardening (Asana `1216667157595351`): SHA-pin every third-party GitHub Action on a mutable tag/branch to a **current-major commit SHA** (no version bumps).

Notably: Pins `danharrin/monorepo-split-github-action` (pushes the subtree splits to 12 repos with `SPLIT_TOKEN`).

## Why

A mutable tag/branch can be silently repointed at attacker code that runs in our workflows with our secrets — the `tj-actions/changed-files` (CVE-2025-30066) attack class. Pinning to an immutable SHA closes it. No behavior change — each ref is pinned to the commit its current major tag already points to. First-party `actions/*` are deferred to a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
